### PR TITLE
Fix artifact display for zero-cost

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -282,7 +282,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             }
             else
             {
-                if (genericCost > 0)
+                bool showGeneric = genericCost > 0 ||
+                                   linkedCard.PrimaryColor == "Artifact" ||
+                                   linkedCard.PrimaryColor == "None";
+
+                if (showGeneric)
                 {
                     costText.text = genericCost.ToString();
                     if (genericCostBG != null) genericCostBG.SetActive(true);
@@ -305,7 +309,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     genericCost = Mathf.Max(creature.manaCost - linkedCard.color.Count, 0);
                 }
 
-                if (genericCost > 0)
+                bool showGeneric = genericCost > 0 ||
+                                   linkedCard.PrimaryColor == "Artifact" ||
+                                   linkedCard.PrimaryColor == "None";
+
+                if (showGeneric)
                 {
                     costText.text = genericCost.ToString();
                     if (genericCostBG != null) genericCostBG.SetActive(true);
@@ -526,7 +534,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 {
                     genericCost = Mathf.Max(creature.manaCost - linkedCard.color.Count, 0);
                 }
-                if (genericCost > 0)
+                bool showGeneric = genericCost > 0 ||
+                                   linkedCard.PrimaryColor == "Artifact" ||
+                                   linkedCard.PrimaryColor == "None";
+
+                if (showGeneric)
                 {
                     costText.text = genericCost.ToString();
                     if (genericCostBG != null) genericCostBG.SetActive(true);
@@ -536,6 +548,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     costText.text = "";
                     if (genericCostBG != null) genericCostBG.SetActive(false);
                 }
+
                 statsText.text = $"{creature.power}/{creature.toughness}";
                 keywordText.text = linkedCard.GetCardText();
 


### PR DESCRIPTION
## Summary
- always show `0` mana cost icon for Artifact cards

## Testing
- `ls test || echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_e_685d550de0c88327baf202acd791253e