### PR TITLE
Refactor visuals and small bug fix

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -981,7 +981,10 @@ public class TurnSystem : MonoBehaviour
                 case TurnPhase.Damage:
                     Debug.Log("→ Resolving combat damage.");
                     if (damageCoroutine != null)
+                    {
                         StopCoroutine(damageCoroutine);
+                        damageCoroutine = null;
+                    }
 
                     damageCoroutine = StartCoroutine(WaitToShowCombatDamage());
                     break;


### PR DESCRIPTION
## Summary
- create helper methods for land icons, type line and mana cost calculations
- clean up `UpdateVisual` and `Setup` with the helpers
- remove unused scale variable and redundant checks
- reset damage coroutine before reuse in `TurnSystem`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d651d1e548327b18bce0b3ee9c9c9