### PR TITLE
Add Burst of Speed sorcery

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -61,6 +61,8 @@ public class CardData
     public SorceryCard.TargetType requiredTargetType = SorceryCard.TargetType.None;
     public int damageToTarget = 0;
 
+    public KeywordAbility keywordAbilityForTarget = KeywordAbility.None;
+
     public SorceryCard.PermanentTypeToDestroy typeOfPermanentToDestroyAll = SorceryCard.PermanentTypeToDestroy.None;
 
     // Passive abilities like Haste, Defender

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2005,6 +2005,19 @@ public static class CardDatabase
                         damageToTarget = 3,
                         artwork = Resources.Load<Sprite>("Art/explosion"),
                     });
+                Add(new CardData //Burst of Speed
+                    {
+                        cardName = "Burst of Speed",
+                        rarity = "Common",
+                        cardType = CardType.Sorcery,
+                        manaCost = 1,
+                        color = new List<string> { "Red" },
+                        requiresTarget = true,
+                        requiredTargetType = SorceryCard.TargetType.Creature,
+                        keywordAbilityForTarget = KeywordAbility.Haste,
+                        rulesText = "Target creature gains haste until the end of turn",
+                        artwork = Resources.Load<Sprite>("Art/explosion"),
+                    });
                 Add(new CardData //Moonfall
                     {
                         cardName = "Moonfall",

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -60,6 +60,7 @@ public static class CardFactory
                 sorcery.damageToTarget = data.damageToTarget;
                 sorcery.destroyTargetIfTypeMatches = data.destroyTargetIfTypeMatches;
                 sorcery.requiredTargetColor = data.requiredTargetColor;
+                sorcery.keywordAbilityForTarget = data.keywordAbilityForTarget;
                 newCard = sorcery;
                 break;
             case CardType.Artifact:

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1433,6 +1433,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 rules += $"Opponent discards {sorcery.cardsToDiscardorDraw} card(s) at random. If can't, you draw a card.\n";
             if (sorcery.eachPlayerGainLifeEqualToLands)
                 rules += $"Each player gains life equal to the number of lands they control.\n";
+            if (sorcery.keywordAbilityForTarget != KeywordAbility.None &&
+                sorcery.requiredTargetType == SorceryCard.TargetType.Creature)
+                rules += $"Target creature gains {sorcery.keywordAbilityForTarget} until end of turn.\n";
             if (sorcery.damageToTarget > 0 &&
                 (sorcery.requiredTargetType == SorceryCard.TargetType.Creature ||
                 sorcery.requiredTargetType == SorceryCard.TargetType.Player ||

--- a/Assets/Scripts/CreatureCard.cs
+++ b/Assets/Scripts/CreatureCard.cs
@@ -11,6 +11,7 @@ public class CreatureCard : Card
     public int tapLifeLossAmount;
     public bool hasSummoningSickness = true;
     public KeywordAbility abilityToGain = KeywordAbility.Flying;
+    public List<KeywordAbility> temporaryKeywordAbilities = new List<KeywordAbility>();
     public CreatureCard blockingThisAttacker;  // If this is a blocker
     public List<CreatureCard> blockedByThisBlocker = new List<CreatureCard>();  // If this is an attacker
 

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -18,6 +18,7 @@ public class SorceryCard : Card
     public int numberOfTokensMax = 0;
     public Card chosenTarget = null;
     public int damageToTarget = 0;
+    public KeywordAbility keywordAbilityForTarget = KeywordAbility.None;
     public bool destroyTargetIfTypeMatches = false;
     public string requiredTargetColor = null;
     public Player chosenPlayerTarget = null;
@@ -292,6 +293,20 @@ public class SorceryCard : Card
             {
                 if (target != null)
                 {
+
+                    if (keywordAbilityForTarget != KeywordAbility.None && target is CreatureCard targetCreature)
+                    {
+                        if (!targetCreature.keywordAbilities.Contains(keywordAbilityForTarget))
+                            targetCreature.keywordAbilities.Add(keywordAbilityForTarget);
+                        if (keywordAbilityForTarget == KeywordAbility.Haste)
+                            targetCreature.hasSummoningSickness = false;
+                        targetCreature.temporaryKeywordAbilities.Add(keywordAbilityForTarget);
+                        GameManager.Instance.FindCardVisual(targetCreature)?.UpdateVisual();
+
+                        GameManager.Instance.UpdateUI();
+                        ResolveEffect(caster);
+                        return;
+                    }
 
                     if (damageToTarget > 0 && target is CreatureCard creature)
                     {

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1006,17 +1006,31 @@ public class TurnSystem : MonoBehaviour
                     // Remove temporary keyword abilities
                     foreach (var card in endingPlayer.Battlefield)
                     {
-                        if (card is CreatureCard creature &&
-                            creature.activatedAbilities != null &&
-                            creature.activatedAbilities.Contains(ActivatedAbility.PayToGainAbility))
+                        if (card is CreatureCard creature)
                         {
-                            if (creature.keywordAbilities.Contains(creature.abilityToGain))
+                            foreach (var temp in creature.temporaryKeywordAbilities)
                             {
-                                creature.keywordAbilities.Remove(creature.abilityToGain);
+                                creature.keywordAbilities.Remove(temp);
+                            }
+                            if (creature.temporaryKeywordAbilities.Count > 0)
+                            {
+                                creature.temporaryKeywordAbilities.Clear();
                                 var visual = GameManager.Instance.FindCardVisual(card);
                                 if (visual != null)
                                     visual.UpdateVisual();
-                                Debug.Log($"{creature.cardName} loses {creature.abilityToGain} at end of turn.");
+                            }
+
+                            if (creature.activatedAbilities != null &&
+                                creature.activatedAbilities.Contains(ActivatedAbility.PayToGainAbility))
+                            {
+                                if (creature.keywordAbilities.Contains(creature.abilityToGain))
+                                {
+                                    creature.keywordAbilities.Remove(creature.abilityToGain);
+                                    var visual = GameManager.Instance.FindCardVisual(card);
+                                    if (visual != null)
+                                        visual.UpdateVisual();
+                                    Debug.Log($"{creature.cardName} loses {creature.abilityToGain} at end of turn.");
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- support temporary keyword abilities for creatures
- add ability for sorcery cards to grant haste
- clean up temporary abilities at end of turn
- new red sorcery "Burst of Speed" grants haste

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685db8def9bc8327b9224d7973d4aff2