### PR TITLE
Fix deck and color state not clearing after loss

### DIFF
--- a/Assets/Scripts/ColorButtonBehavior.cs
+++ b/Assets/Scripts/ColorButtonBehavior.cs
@@ -40,6 +40,12 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
     private static Color startingBGColor;
     private static float bgFadeSpeed = 2f;
 
+    public static void ResetSelections()
+    {
+        selectedColors.Clear();
+        backgroundPanelStatic = null;
+    }
+
     public GameObject startButton;
 
     private bool isSelected = false;

--- a/Assets/Scripts/MainMenuController.cs
+++ b/Assets/Scripts/MainMenuController.cs
@@ -30,5 +30,9 @@ public class MainMenuController : MonoBehaviour
         Debug.LogWarning("[DEV] Clearing all PlayerPrefs!");
         PlayerPrefs.DeleteAll();
         PlayerPrefs.Save();
+
+        // Reset any generated deck and previously selected colors
+        DeckHolder.SelectedDeck = null;
+        ColorButtonBehavior.ResetSelections();
     }
 }


### PR DESCRIPTION
## Summary
- reset color selection in `ColorButtonBehavior`
- clear selected deck and colors when returning to the main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e2dcf92488327b23ddfb6fb82fe61