### PR TITLE
Adjust artifact destruction rules

### DIFF
--- a/Assets/Scripts/CardAbility.cs
+++ b/Assets/Scripts/CardAbility.cs
@@ -15,4 +15,5 @@ public class CardAbility
     public string description;
     public bool requiresTarget = false;
     public SorceryCard.TargetType requiredTargetType = SorceryCard.TargetType.None;
+    public bool excludeArtifactCreatures = false;
 }

--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -61,6 +61,7 @@ public class CardData
     public bool swapGraveyardAndLibrary = false;
     public bool requiresTarget = false;
     public SorceryCard.TargetType requiredTargetType = SorceryCard.TargetType.None;
+    public bool excludeArtifactCreatures = false;
     public int damageToTarget = 0;
     public KeywordAbility keywordToGrant = KeywordAbility.None;
 

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -74,7 +74,7 @@ public static class CardDatabase
                             new CardAbility
                             {
                                 timing = TriggerTiming.OnEnter,
-                                description = "you may destroy target artifact.",
+                                description = "When this creature enters, you may destroy target non-creature artifact.",
                                 requiresTarget = true,
                                 requiredTargetType = SorceryCard.TargetType.Artifact,
                                 effect = (Player owner, Card target) =>
@@ -603,13 +603,17 @@ public static class CardDatabase
                         new CardAbility
                         {
                             timing = TriggerTiming.OnEnter,
-                            description = "you may destroy target creature.",
+                            description = "you may destroy target non-artifact creature.",
                             requiresTarget = true,
                             requiredTargetType = SorceryCard.TargetType.Creature,
+                            excludeArtifactCreatures = true,
                             effect = (Player owner, Card target) =>
                             {
-                                Player controller = GameManager.Instance.GetOwnerOfCard(target);
-                                GameManager.Instance.SendToGraveyard(target, controller);
+                                if (target is CreatureCard creature && !creature.color.Contains("Artifact"))
+                                {
+                                    Player controller = GameManager.Instance.GetOwnerOfCard(target);
+                                    GameManager.Instance.SendToGraveyard(target, controller);
+                                }
                             }
                         }
                     }
@@ -1884,6 +1888,8 @@ public static class CardDatabase
                         requiresTarget = true,
                         requiredTargetType = SorceryCard.TargetType.Creature,
                         destroyTargetIfTypeMatches = true,
+                        excludeArtifactCreatures = true,
+                        rulesText = "Destroy target non-artifact creature. Create a Zombie token.",
                         tokenToCreate = "Zombie",
                         numberOfTokensMin = 1,
                         numberOfTokensMax = 1,
@@ -1962,6 +1968,7 @@ public static class CardDatabase
                             requiresTarget = true,
                             requiredTargetType = SorceryCard.TargetType.Artifact,
                             destroyTargetIfTypeMatches = true,
+                            rulesText = "Destroy target non-creature artifact.",
                             artwork = Resources.Load<Sprite>("Art/melt"),
                         });
                 Add(new CardData //Dash

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -63,6 +63,7 @@ public static class CardFactory
                 sorcery.destroyTargetIfTypeMatches = data.destroyTargetIfTypeMatches;
                 sorcery.keywordToGrant = data.keywordToGrant;
                 sorcery.requiredTargetColor = data.requiredTargetColor;
+                sorcery.excludeArtifactCreatures = data.excludeArtifactCreatures;
                 newCard = sorcery;
                 break;
             case CardType.Artifact:

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -534,8 +534,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 var ability = GameManager.Instance.optionalAbility;
                 bool isValid = false;
 
-                if (ability.requiredTargetType == SorceryCard.TargetType.Creature && clicked is CreatureCard)
-                    isValid = true;
+                if (ability.requiredTargetType == SorceryCard.TargetType.Creature && clicked is CreatureCard creature)
+                    isValid = !(ability.excludeArtifactCreatures && creature.color.Contains("Artifact"));
 
                 if (ability.requiredTargetType == SorceryCard.TargetType.Artifact && clicked is ArtifactCard)
                     isValid = true;
@@ -596,7 +596,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     if (GameManager.Instance.GetOwnerOfCard(card).Battlefield.Contains(card))
                     {
                         var protection = spell.GetProtectionKeyword(spell.PrimaryColor);
-                        if (!targetCreature.keywordAbilities.Contains(protection))
+                        bool notArtifact = !(spell.excludeArtifactCreatures && targetCreature.color.Contains("Artifact"));
+                        if (!targetCreature.keywordAbilities.Contains(protection) && notArtifact)
                             valid = true;
                     }
                 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1226,7 +1226,8 @@ public class GameManager : MonoBehaviour
                 Card target = targetVisual.linkedCard;
 
                 bool correctType =
-                    (targetingAbility.requiredTargetType == SorceryCard.TargetType.Creature && target is CreatureCard) ||
+                    (targetingAbility.requiredTargetType == SorceryCard.TargetType.Creature && target is CreatureCard creature &&
+                        !(targetingAbility.excludeArtifactCreatures && creature.color.Contains("Artifact"))) ||
                     (targetingAbility.requiredTargetType == SorceryCard.TargetType.Land && target is LandCard) ||
                     (targetingAbility.requiredTargetType == SorceryCard.TargetType.Artifact && target is ArtifactCard);
 
@@ -1257,7 +1258,8 @@ public class GameManager : MonoBehaviour
             {
                 // Validate type
                 bool correctType =
-                    (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Creature && chosen is CreatureCard) ||
+                    (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Creature && chosen is CreatureCard creatureT &&
+                        !(targetingSorcery.excludeArtifactCreatures && creatureT.color.Contains("Artifact"))) ||
                     (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Land && chosen is LandCard) ||
                     (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Artifact && chosen is ArtifactCard) ||
                     (targetingSorcery.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer && chosen is CreatureCard);

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -23,6 +23,7 @@ public class SorceryCard : Card
     public bool destroyTargetIfTypeMatches = false;
     public KeywordAbility keywordToGrant = KeywordAbility.None;
     public string requiredTargetColor = null;
+    public bool excludeArtifactCreatures = false;
     public Player chosenPlayerTarget = null;
 
     public TargetType requiredTargetType = TargetType.None;
@@ -330,7 +331,8 @@ public class SorceryCard : Card
                     if (destroyTargetIfTypeMatches)
                     {
                         bool typeMatches =
-                            (requiredTargetType == TargetType.Creature && target is CreatureCard) ||
+                            (requiredTargetType == TargetType.Creature && target is CreatureCard creature &&
+                                !(excludeArtifactCreatures && creature.color.Contains("Artifact"))) ||
                             (requiredTargetType == TargetType.Land && target is LandCard) ||
                             (requiredTargetType == TargetType.Artifact && target is ArtifactCard);
 

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -436,7 +436,8 @@ public class TurnSystem : MonoBehaviour
 
                                                     Card target = opponent.Battlefield
                                                         .Where(c =>
-                                                            (ability.requiredTargetType == SorceryCard.TargetType.Creature && c is CreatureCard) ||
+                                                            (ability.requiredTargetType == SorceryCard.TargetType.Creature && c is CreatureCard creatureT &&
+                                                                !(ability.excludeArtifactCreatures && creatureT.color.Contains("Artifact"))) ||
                                                             (ability.requiredTargetType == SorceryCard.TargetType.Artifact && c is ArtifactCard) ||
                                                             (ability.requiredTargetType == SorceryCard.TargetType.Land && c is LandCard))
                                                         .OrderByDescending(c => CardDatabase.GetCardData(c.cardName)?.manaCost ?? 0)
@@ -480,6 +481,7 @@ public class TurnSystem : MonoBehaviour
                                             // Pick enemy creature with the highest mana cost
                                             var target = opponent.Battlefield
                                                 .OfType<CreatureCard>()
+                                                .Where(c => !(sorcery.excludeArtifactCreatures && c.color.Contains("Artifact")))
                                                 .OrderByDescending(c =>
                                                 {
                                                     var data = CardDatabase.GetCardData(c.cardName);


### PR DESCRIPTION
## Summary
- expand card ability data to support artifact creature restrictions
- update card factory and gameplay logic to respect new `excludeArtifactCreatures` flag
- modify targeting checks in GameManager, CardVisual, and AI logic
- update card texts and abilities for Melt, Iconoclast Monk, Hired Assassin, and Forced Mummification

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685e782a50f08327a5a53371b9088e6b