### PR TITLE
Fix discard rules for Drain and Burn Mind

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -52,6 +52,7 @@ public class CardData
     public int lifeToLoseForOpponent;
     public int lifeLossForBothPlayers;
     public int cardsToDiscardorDraw;
+    public bool drawIfOpponentCantDiscard = true;
     public int damageToEachCreatureAndPlayer;
     public int manaToGain;
     public int manaToGainMin = 0;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -1967,6 +1967,7 @@ public static class CardDatabase
                         color = new List<string> { "Black" },
                         artwork = Resources.Load<Sprite>("Art/forget"),
                         cardsToDiscardorDraw = 1,
+                        drawIfOpponentCantDiscard = true,
                     });
                 Add(new CardData //Massacre
                     {
@@ -2123,6 +2124,7 @@ public static class CardDatabase
                         manaCost = 2,
                         color = new List<string> { "Blue", "Black" },
                         cardsToDiscardorDraw = 1,
+                        drawIfOpponentCantDiscard = false,
                         cardsToDraw = 1,
                         artwork = Resources.Load<Sprite>("Art/drain_mind")
                         });
@@ -2134,6 +2136,7 @@ public static class CardDatabase
                     manaCost = 2,
                     color = new List<string> { "Black", "Red" },
                     cardsToDiscardorDraw = 1,
+                    drawIfOpponentCantDiscard = false,
                     lifeToLoseForOpponent = 2,
                     artwork = Resources.Load<Sprite>("Art/burn_mind")
                     });

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -48,6 +48,7 @@ public static class CardFactory
                 sorcery.lifeLossForBothPlayers = data.lifeLossForBothPlayers;
                 sorcery.cardsToDraw = data.cardsToDraw;
                 sorcery.cardsToDiscardorDraw = data.cardsToDiscardorDraw;
+                sorcery.drawIfOpponentCantDiscard = data.drawIfOpponentCantDiscard;
                 sorcery.eachPlayerGainLifeEqualToLands = data.eachPlayerGainLifeEqualToLands;
                 sorcery.typeOfPermanentToDestroyAll = data.typeOfPermanentToDestroyAll;
                 sorcery.exileAllCreaturesFromGraveyards = data.exileAllCreaturesFromGraveyards;

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1438,7 +1438,12 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 }
             }
             if (sorcery.cardsToDiscardorDraw > 0)
-                rules += $"Opponent discards {sorcery.cardsToDiscardorDraw} card(s) at random. If can't, you draw a card.\n";
+            {
+                rules += $"Opponent discards {sorcery.cardsToDiscardorDraw} card(s) at random.";
+                if (sorcery.drawIfOpponentCantDiscard)
+                    rules += " If can't, you draw a card.";
+                rules += "\n";
+            }
             if (sorcery.eachPlayerGainLifeEqualToLands)
                 rules += $"Each player gains life equal to the number of lands they control.\n";
             if (sorcery.damageToTarget > 0 &&

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -10,6 +10,7 @@ public class SorceryCard : Card
     public int lifeToLoseForOpponent = 0;
     public int lifeLossForBothPlayers = 0;
     public int cardsToDiscardorDraw = 0;
+    public bool drawIfOpponentCantDiscard = true;
     public int damageToEachCreatureAndPlayer = 0;
     public int manaToGainMin = 0;
     public int manaToGainMax = 0;
@@ -148,7 +149,7 @@ public class SorceryCard : Card
                         }
                     }
 
-                    if (!opponentDiscarded)
+                    if (!opponentDiscarded && drawIfOpponentCantDiscard)
                     {
                         GameManager.Instance.DrawCard(caster);
                         Debug.Log($"{caster} draws a card because opponent had nothing to discard.");


### PR DESCRIPTION
## Summary
- allow Sorcery cards to specify if caster draws when opponent can't discard
- update card factory and visuals to respect new flag
- adjust Drain Mind and Burn Mind so they no longer draw when opponent has no cards
- keep Forget unchanged with draw-if-cant effect

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eed01565c8327a32227a651cdc124