### PR TITLE
Add Undead Army zombie card with decay ability

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -997,6 +997,19 @@ public static class CardDatabase
                     },
                     artwork = Resources.Load<Sprite>("Art/wicked_witch")
                     });
+                Add(new CardData //Undead Army
+                    {
+                    cardName = "Undead Army",
+                    rarity = "Uncommon",
+                    manaCost = 8,
+                    color = new List<string> { "Black" },
+                    cardType = CardType.Creature,
+                    power = 8,
+                    toughness = 8,
+                    subtypes = new List<string> { "Zombie" },
+                    rulesText = "Whenever this creature attacks or blocks, put a -1/-1 counter on this creature at the end of combat.",
+                    artwork = Resources.Load<Sprite>("Art/undead_army")
+                    });
                 Add(new CardData // Zombie Token
                     {
                         cardName = "Zombie",

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -609,6 +609,17 @@ public class GameManager : MonoBehaviour
             }
         }
 
+        foreach (var creature in humanPlayer.Battlefield.Concat(aiPlayer.Battlefield).OfType<CreatureCard>())
+        {
+            if (creature.cardName == "Undead Army" &&
+                (currentAttackers.Contains(creature) || creature.blockingThisAttacker != null))
+            {
+                creature.AddMinusOneCounter();
+                var vis = FindCardVisual(creature);
+                if (vis != null) vis.UpdateVisual();
+            }
+        }
+
         CheckDeaths(humanPlayer);
         CheckDeaths(aiPlayer);
 
@@ -1880,6 +1891,20 @@ public class GameManager : MonoBehaviour
 
                     yield return new WaitForSeconds(0.05f);
                 }
+
+                foreach (var creature in humanPlayer.Battlefield.Concat(aiPlayer.Battlefield).OfType<CreatureCard>())
+                {
+                    if (creature.cardName == "Undead Army" &&
+                        (currentAttackers.Contains(creature) || creature.blockingThisAttacker != null))
+                    {
+                        creature.AddMinusOneCounter();
+                        var vis = FindCardVisual(creature);
+                        if (vis != null) vis.UpdateVisual();
+                    }
+                }
+
+                CheckDeaths(humanPlayer);
+                CheckDeaths(aiPlayer);
 
                 foreach (var card in humanPlayer.Battlefield)
                 {


### PR DESCRIPTION
## Summary
- add card data for **Undead Army**
- apply end of combat -1/-1 counter to attacking or blocking Undead Army creatures

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_685f075a734483279efae210868f16e3