### PR TITLE
Add Mirrorbreak card

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -22,6 +22,7 @@ public class CardData
     public bool entersTapped = false;
     public bool isToken = false;
     public bool destroyTargetIfTypeMatches = false;
+    public bool destroyAllWithSameName = false;
     
     public int numberOfTokensMin = 0;
     public int numberOfTokensMax = 0;   

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2027,6 +2027,18 @@ public static class CardDatabase
                         artwork = Resources.Load<Sprite>("Art/massacre"),
                         typeOfPermanentToDestroyAll = SorceryCard.PermanentTypeToDestroy.Creature
                     });
+                Add(new CardData //Mirrorbreak
+                    {
+                        cardName = "Mirrorbreak",
+                        rarity = "Uncommon",
+                        cardType = CardType.Sorcery,
+                        manaCost = 3,
+                        color = new List<string> { "Black" },
+                        requiresTarget = true,
+                        requiredTargetType = SorceryCard.TargetType.Creature,
+                        destroyAllWithSameName = true,
+                        artwork = Resources.Load<Sprite>("Art/mirrorbreak"),
+                    });
             // RED
                 Add(new CardData //To dig a hole
                         {

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -63,6 +63,7 @@ public static class CardFactory
                 sorcery.requiredTargetType = data.requiredTargetType;
                 sorcery.damageToTarget = data.damageToTarget;
                 sorcery.destroyTargetIfTypeMatches = data.destroyTargetIfTypeMatches;
+                sorcery.destroyAllWithSameName = data.destroyAllWithSameName;
                 sorcery.keywordToGrant = data.keywordToGrant;
                 sorcery.requiredTargetColor = data.requiredTargetColor;
                 sorcery.excludeArtifactCreatures = data.excludeArtifactCreatures;

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1497,6 +1497,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 };
                 rules += $"Destroy all {typeStr}.\n";
             }
+            if (sorcery.destroyAllWithSameName)
+                rules += "Destroy target creature and each other creature with the same name.\n";
             if (sorcery.exileAllCreaturesFromGraveyards)
                 rules += "Exile all creature cards from all graveyards.\n";
             if (sorcery.damageToEachCreatureAndPlayer > 0)

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -22,6 +22,7 @@ public class SorceryCard : Card
     public Card chosenTarget = null;
     public int damageToTarget = 0;
     public bool destroyTargetIfTypeMatches = false;
+    public bool destroyAllWithSameName = false;
     public KeywordAbility keywordToGrant = KeywordAbility.None;
     public string requiredTargetColor = null;
     public bool excludeArtifactCreatures = false;
@@ -326,6 +327,28 @@ public class SorceryCard : Card
 
                         GameManager.Instance.UpdateUI();
                         ResolveEffect(caster); // Add this line
+                        return;
+                    }
+
+                    if (destroyAllWithSameName && target is CreatureCard)
+                    {
+                        string name = target.cardName;
+                        List<(Card card, Player owner)> toDestroy = new List<(Card, Player)>();
+                        foreach (var player in new[] { GameManager.Instance.humanPlayer, GameManager.Instance.aiPlayer })
+                        {
+                            foreach (var card in player.Battlefield.OfType<CreatureCard>().Where(c => c.cardName == name).ToList())
+                            {
+                                toDestroy.Add((card, player));
+                            }
+                        }
+                        foreach (var (card, owner) in toDestroy)
+                        {
+                            GameManager.Instance.SendToGraveyard(card, owner);
+                        }
+
+                        Debug.Log($"{cardName} destroyed {toDestroy.Count} copies of {name}.");
+
+                        ResolveEffect(caster);
                         return;
                     }
 


### PR DESCRIPTION
## Summary
- add `destroyAllWithSameName` option for sorceries
- implement Mirrorbreak effect and display
- include new card in database

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685f0c33d2948327b02ed76a6d4361d5