### PR TITLE
Add Nocturnal Spectre card

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -239,6 +239,8 @@ public class Card
                     lines.Add("Whenever a creature dies or is discarded, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnCombatDamageToPlayer)
                     lines.Add("Whenever a creature deals combat damage to a player, " + ability.description);
+                else if (ability.timing == TriggerTiming.OnOpponentDiscard)
+                    lines.Add("Whenever an opponent discards a card, " + ability.description);
             }
 
             if (keywordAbilities != null)

--- a/Assets/Scripts/CardAbility.cs
+++ b/Assets/Scripts/CardAbility.cs
@@ -9,6 +9,7 @@ public enum TriggerTiming
     OnLifeGain,
     OnCardDraw,
     OnCreatureDiesOrDiscarded,
+    OnOpponentDiscard,
     OnCombatDamageToPlayer,
 }
 

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -1025,6 +1025,41 @@ public static class CardDatabase
                         keywordAbilities = new List<KeywordAbility> { },
                         artwork = Resources.Load<Sprite>("Art/zombie_token")
                     });
+
+                Add(new CardData //Nocturnal Spectre
+                    {
+                        cardName = "Nocturnal Spectre",
+                        rarity = "Uncommon",
+                        manaCost = 4,
+                        color = new List<string> { "Black" },
+                        cardType = CardType.Creature,
+                        power = 2,
+                        toughness = 2,
+                        subtypes = new List<string> { "Spectre" },
+                        keywordAbilities = new List<KeywordAbility>
+                        {
+                            KeywordAbility.Flying
+                        },
+                        artwork = Resources.Load<Sprite>("Art/nocturnal_spectre"),
+                        abilities = new List<CardAbility>
+                        {
+                            new CardAbility
+                            {
+                                timing = TriggerTiming.OnOpponentDiscard,
+                                description = "this creature gets +2/+2 until end of turn.",
+                                effect = (Player owner, Card selfCard) =>
+                                {
+                                    if (selfCard is CreatureCard creature)
+                                    {
+                                        creature.AddTemporaryBuff(2, 2);
+                                        var vis = GameManager.Instance.FindCardVisual(creature);
+                                        if (vis != null)
+                                            vis.UpdateVisual();
+                                    }
+                                }
+                            }
+                        }
+                    });
                 Add(new CardData // Demon Token
                     {
                         cardName = "Demon",

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -429,6 +429,10 @@ public class GameManager : MonoBehaviour
 
             owner.Battlefield.Remove(card);
             owner.Hand.Remove(card);
+
+            if (discardedFromHand)
+                NotifyOpponentDiscard(owner);
+
             Debug.Log($"{card.cardName} is being sent to the graveyard.");
 
             if (card is CreatureCard && (diedFromBattlefield || discardedFromHand))
@@ -2120,6 +2124,26 @@ public class GameManager : MonoBehaviour
                 }
             }
             lastCardsDrawnAmount = 0;
+        }
+
+        public void NotifyOpponentDiscard(Player discardingPlayer)
+        {
+            foreach (var player in new[] { humanPlayer, aiPlayer })
+            {
+                if (player == discardingPlayer)
+                    continue;
+
+                foreach (var card in player.Battlefield.ToList())
+                {
+                    foreach (var ability in card.abilities)
+                    {
+                        if (ability.timing == TriggerTiming.OnOpponentDiscard && ability.effect != null)
+                        {
+                            ability.effect.Invoke(player, card);
+                        }
+                    }
+                }
+            }
         }
 
         public void NotifyCreatureDiesOrDiscarded(Card creature, Player owner)


### PR DESCRIPTION
## Summary
- add new trigger `OnOpponentDiscard`
- show text for the discard trigger in card UI
- fire the new discard trigger from `SendToGraveyard`
- add `NotifyOpponentDiscard` handler
- create the black creature "Nocturnal Spectre" that grows when opponents discard

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0f7501248327b195f6feeea2391e