### PR TITLE
Add Goblin Beastmaster card

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -253,6 +253,8 @@ public class Card
                     lines.Add("Players can only cast creature spells.");
                 if (keywordAbilities.Contains(KeywordAbility.CreatureSpellsCostOneLess))
                     lines.Add("Creature spells you cast cost 1 less.");
+                if (keywordAbilities.Contains(KeywordAbility.BeastCreatureSpellsCostOneLess))
+                    lines.Add("Beast creature spells you cast cost 1 less.");
             }
 
             return string.Join("\n", lines);

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -1205,6 +1205,22 @@ public static class CardDatabase
                     },
                     artwork = Resources.Load<Sprite>("Art/goblin_puncher")
                     });
+                Add(new CardData //Goblin Beastmaster
+                    {
+                    cardName = "Goblin Beastmaster",
+                    rarity = "Common",
+                    manaCost = 2,
+                    color = new List<string> { "Red" },
+                    cardType = CardType.Creature,
+                    power = 1,
+                    toughness = 1,
+                    subtypes = new List<string> { "Goblin", "Shaman" },
+                    keywordAbilities = new List<KeywordAbility>
+                    {
+                        KeywordAbility.BeastCreatureSpellsCostOneLess
+                    },
+                    artwork = Resources.Load<Sprite>("Art/goblin_beastmaster")
+                    });
                 Add(new CardData //Thundermare
                     {
                     cardName = "Thundermare",

--- a/Assets/Scripts/CreatureCard.cs
+++ b/Assets/Scripts/CreatureCard.cs
@@ -59,6 +59,9 @@ public class CreatureCard : Card
     {
         var cost = GameManager.Instance.GetManaCostBreakdown(manaCost, color);
         int reduction = GameManager.Instance.GetCreatureCostReduction(player);
+        CardData data = CardDatabase.GetCardData(cardName);
+        if (data != null && data.subtypes.Contains("Beast"))
+            reduction += GameManager.Instance.GetBeastCreatureCostReduction(player);
         if (reduction > 0 && cost.ContainsKey("Colorless"))
             cost["Colorless"] = Mathf.Max(0, cost["Colorless"] - reduction);
         if (player.ColoredMana.CanPay(cost))

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -213,6 +213,9 @@ public class GameManager : MonoBehaviour
             {
                 var cost = GetManaCostBreakdown(card.manaCost, card.color);
                 int reduction = GetCreatureCostReduction(player);
+                CardData data = CardDatabase.GetCardData(card.cardName);
+                if (data != null && data.subtypes.Contains("Beast"))
+                    reduction += GetBeastCreatureCostReduction(player);
                 if (reduction > 0 && cost.ContainsKey("Colorless"))
                     cost["Colorless"] = Mathf.Max(0, cost["Colorless"] - reduction);
                 if (player.ColoredMana.CanPay(cost))
@@ -1105,6 +1108,12 @@ public class GameManager : MonoBehaviour
     {
         return player.Battlefield.Count(card => card.keywordAbilities != null &&
             card.keywordAbilities.Contains(KeywordAbility.CreatureSpellsCostOneLess));
+    }
+
+    public int GetBeastCreatureCostReduction(Player player)
+    {
+        return player.Battlefield.Count(card => card.keywordAbilities != null &&
+            card.keywordAbilities.Contains(KeywordAbility.BeastCreatureSpellsCostOneLess));
     }
 
     public void TryGainLife(Player player, int amount)

--- a/Assets/Scripts/KeywordAbility.cs
+++ b/Assets/Scripts/KeywordAbility.cs
@@ -25,6 +25,7 @@ public enum KeywordAbility
     NoLifeGain,
     OnlyCastCreatureSpells,
     CreatureSpellsCostOneLess,
+    BeastCreatureSpellsCostOneLess,
 }
 
 public enum ActivatedAbility

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -338,6 +338,9 @@ public class TurnSystem : MonoBehaviour
                                 {
                                     var cost = GameManager.Instance.GetManaCostBreakdown(creature.manaCost, creature.color);
                                     int reduction = GameManager.Instance.GetCreatureCostReduction(ai);
+                                    CardData data = CardDatabase.GetCardData(creature.cardName);
+                                    if (data != null && data.subtypes.Contains("Beast"))
+                                        reduction += GameManager.Instance.GetBeastCreatureCostReduction(ai);
                                     if (reduction > 0 && cost.ContainsKey("Colorless"))
                                         cost["Colorless"] = Mathf.Max(0, cost["Colorless"] - reduction);
                                     if (EnsureManaForCost(ai, cost))


### PR DESCRIPTION
## Summary
- add new keyword ability `BeastCreatureSpellsCostOneLess`
- implement Beast creature cost reduction in `GameManager`, `CreatureCard`, and AI logic
- display new ability text on cards
- add `Goblin Beastmaster` common red creature to the card database

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa7efb12083279038b2b61a0d8e3c