### PR TITLE
Add Muscle Blast sorcery card

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2226,6 +2226,18 @@ public static class CardDatabase
                     manaToGainMax = 6,
                     artwork = Resources.Load<Sprite>("Art/rolling_energy"),
                     });
+                Add(new CardData { //Muscle Blast
+                    cardName = "Muscle Blast",
+                    rarity = "Uncommon",
+                    cardType = CardType.Sorcery,
+                    manaCost = 6,
+                    color = new List<string> { "Green" },
+                    requiresTarget = true,
+                    requiredTargetType = SorceryCard.TargetType.Creature,
+                    powerBuff = 6,
+                    toughnessBuff = 6,
+                    artwork = Resources.Load<Sprite>("Art/muscle_blast"),
+                    });
             ///MULTI
                 Add(new CardData //Drain mind
                         {

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -67,6 +67,8 @@ public static class CardFactory
                 sorcery.keywordToGrant = data.keywordToGrant;
                 sorcery.requiredTargetColor = data.requiredTargetColor;
                 sorcery.excludeArtifactCreatures = data.excludeArtifactCreatures;
+                sorcery.buffPower = data.powerBuff;
+                sorcery.buffToughness = data.toughnessBuff;
                 newCard = sorcery;
                 break;
             case CardType.Artifact:

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -400,7 +400,16 @@ public class SorceryCard : Card
 
                     Debug.Log($"{keywordCreature.cardName} gains {keywordToGrant} until end of turn.");
                 }
-                else if (!destroyTargetIfTypeMatches && damageToTarget <= 0)
+                if ((buffPower != 0 || buffToughness != 0) && target is CreatureCard buffCreature)
+                {
+                    buffCreature.AddTemporaryBuff(buffPower, buffToughness);
+                    var visual = GameManager.Instance.FindCardVisual(buffCreature);
+                    if (visual != null)
+                        visual.UpdateVisual();
+
+                    Debug.Log($"{buffCreature.cardName} gets +{buffPower}/+{buffToughness} until end of turn.");
+                }
+                else if (!destroyTargetIfTypeMatches && damageToTarget <= 0 && keywordToGrant == KeywordAbility.None)
                 {
                     Debug.LogWarning($"{cardName} resolved on {target.cardName}, but did nothing.");
                 }


### PR DESCRIPTION
## Summary
- allow sorceries to pass buff values through the card factory
- handle buff effects when sorcery resolves on a creature
- add new green sorcery card Muscle Blast that grants +6/+6

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685fc79e01a08327abb6aafabfef59b9