### PR TITLE
Fix sorcery positioning in stack zone

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -273,6 +273,8 @@ public class GameManager : MonoBehaviour
                     // Move visual to the stack zone
                     visual.transform.SetParent(stackZone, false);
                     visual.transform.localPosition = Vector3.zero;
+                    visual.transform.localRotation = Quaternion.identity;
+                    visual.transform.localScale = Vector3.one;
                     SoundManager.Instance.PlaySound(SoundManager.Instance.cardPlay);
                     StartCoroutine(ResolveSorceryAfterDelay(sorcery, visual, player));
                 }
@@ -1388,6 +1390,8 @@ public class GameManager : MonoBehaviour
 
                 targetingVisual.transform.SetParent(stackZone, false);
                 targetingVisual.transform.localPosition = Vector3.zero;
+                targetingVisual.transform.localRotation = Quaternion.identity;
+                targetingVisual.transform.localScale = Vector3.one;
                 SoundManager.Instance.PlaySound(SoundManager.Instance.cardPlay);
 
                 if (targetingVisual != null)
@@ -1441,6 +1445,8 @@ public class GameManager : MonoBehaviour
             // Move visual to stack
             targetingVisual.transform.SetParent(stackZone, false);
             targetingVisual.transform.localPosition = Vector3.zero;
+            targetingVisual.transform.localRotation = Quaternion.identity;
+            targetingVisual.transform.localScale = Vector3.one;
             SoundManager.Instance.PlaySound(SoundManager.Instance.cardPlay);
 
             StartCoroutine(ResolveTargetedSorceryOnPlayerAfterDelay(targetPlayer, targetingPlayer, targetingSorcery, targetingVisual));


### PR DESCRIPTION
## Summary
- ensure sorcery visuals reset rotation and scale when moved to the stack

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fea21573c832797a837fe5e895b24