### PR TITLE
Centralize GetProtectionKeyword

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -587,7 +587,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     // Is on battlefield and not protected
                     if (GameManager.Instance.GetOwnerOfCard(card).Battlefield.Contains(card))
                     {
-                        var protection = spell.GetProtectionKeyword(spell.PrimaryColor);
+                        var protection = ProtectionUtils.GetProtectionKeyword(spell.PrimaryColor);
                         bool notArtifact = !(spell.excludeArtifactCreatures && targetCreature.color.Contains("Artifact"));
                         if (!targetCreature.keywordAbilities.Contains(protection) && notArtifact)
                             valid = true;
@@ -1099,7 +1099,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                             return;
                         }
                         // Prevent blocking if attacker has protection from blocker's color
-                        if (clickedCreature.color.Any(c => attacker.keywordAbilities.Contains(GetProtectionKeyword(c))))
+                        if (clickedCreature.color.Any(c => attacker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c))))
                         {
                             Debug.Log($"{attacker.cardName} has protection from {clickedCreature.color}, so it can't be blocked by {clickedCreature.cardName}.");
                             return;
@@ -1523,18 +1523,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             keywordText.text = rules.Trim();
             }
 
-        private KeywordAbility GetProtectionKeyword(string color)
-            {
-                return color switch
-                {
-                    "White" => KeywordAbility.ProtectionFromWhite,
-                    "Blue" => KeywordAbility.ProtectionFromBlue,
-                    "Black" => KeywordAbility.ProtectionFromBlack,
-                    "Red" => KeywordAbility.ProtectionFromRed,
-                    "Green" => KeywordAbility.ProtectionFromGreen,
-                    _ => KeywordAbility.None
-                };
-            }
+
 
         public void EnableTargetingHighlight(bool enable)
             {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -538,8 +538,8 @@ public class GameManager : MonoBehaviour
 
                 foreach (var blocker in blockers)
                 {
-                    bool attackerProtected = attacker.color.Any(c => blocker.keywordAbilities.Contains(GetProtectionKeyword(c)));
-                    bool blockerProtected = blocker.color.Any(c => attacker.keywordAbilities.Contains(GetProtectionKeyword(c)));
+                    bool attackerProtected = attacker.color.Any(c => blocker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
+                    bool blockerProtected = blocker.color.Any(c => attacker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
 
                     int damageToBlocker = 0;
                     if (!blockerProtected)
@@ -1148,18 +1148,7 @@ public class GameManager : MonoBehaviour
             ShowFloatingHeal(amount, enemyLifeContainer);
     }
 
-    private KeywordAbility GetProtectionKeyword(string color)
-    {
-        return color switch
-        {
-            "White" => KeywordAbility.ProtectionFromWhite,
-            "Blue" => KeywordAbility.ProtectionFromBlue,
-            "Black" => KeywordAbility.ProtectionFromBlack,
-            "Red" => KeywordAbility.ProtectionFromRed,
-            "Green" => KeywordAbility.ProtectionFromGreen,
-            _ => KeywordAbility.None
-        };
-    }
+
 
     public void BeginTargetSelection(SorceryCard sorcery, Player caster, CardVisual visual)
         {
@@ -1484,7 +1473,7 @@ public class GameManager : MonoBehaviour
         {
             if (card is CreatureCard creature && targetingSorcery != null)
             {
-                KeywordAbility protection = targetingSorcery.GetProtectionKeyword(targetingSorcery.PrimaryColor);
+                KeywordAbility protection = ProtectionUtils.GetProtectionKeyword(targetingSorcery.PrimaryColor);
                 return creature.keywordAbilities.Contains(protection);
             }
 
@@ -1796,8 +1785,8 @@ public class GameManager : MonoBehaviour
 
                     foreach (var blocker in blockers)
                     {
-                        bool attackerProtected = attacker.color.Any(c => blocker.keywordAbilities.Contains(GetProtectionKeyword(c)));
-                        bool blockerProtected = blocker.color.Any(c => attacker.keywordAbilities.Contains(GetProtectionKeyword(c)));
+                        bool attackerProtected = attacker.color.Any(c => blocker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
+                        bool blockerProtected = blocker.color.Any(c => attacker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
 
                         int damageToBlocker = 0;
                         if (!blockerProtected)

--- a/Assets/Scripts/ProtectionUtils.cs
+++ b/Assets/Scripts/ProtectionUtils.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class ProtectionUtils
+{
+    public static KeywordAbility GetProtectionKeyword(string color)
+    {
+        return color switch
+        {
+            "White" => KeywordAbility.ProtectionFromWhite,
+            "Blue" => KeywordAbility.ProtectionFromBlue,
+            "Black" => KeywordAbility.ProtectionFromBlack,
+            "Red" => KeywordAbility.ProtectionFromRed,
+            "Green" => KeywordAbility.ProtectionFromGreen,
+            _ => KeywordAbility.None
+        };
+    }
+}

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -265,7 +265,7 @@ public class SorceryCard : Card
                         // Damage to each creature
                         foreach (var creature in player.Battlefield.OfType<CreatureCard>())
                         {
-                            KeywordAbility protection = GetProtectionKeyword(this.PrimaryColor);
+                            KeywordAbility protection = ProtectionUtils.GetProtectionKeyword(this.PrimaryColor);
 
                             if (creature.keywordAbilities.Contains(protection))
                             {
@@ -313,7 +313,7 @@ public class SorceryCard : Card
 
                     if (damageToTarget > 0 && target is CreatureCard creature)
                     {
-                        KeywordAbility protection = GetProtectionKeyword(PrimaryColor);
+                        KeywordAbility protection = ProtectionUtils.GetProtectionKeyword(PrimaryColor);
                         if (creature.keywordAbilities.Contains(protection))
                         {
                             Debug.Log($"{creature.cardName} is protected from {color}, takes no damage.");
@@ -418,18 +418,7 @@ public class SorceryCard : Card
                 ResolveEffect(caster);
             }
 
-        public KeywordAbility GetProtectionKeyword(string color)
-            {
-                return color switch
-                {
-                    "White" => KeywordAbility.ProtectionFromWhite,
-                    "Blue" => KeywordAbility.ProtectionFromBlue,
-                    "Black" => KeywordAbility.ProtectionFromBlack,
-                    "Red" => KeywordAbility.ProtectionFromRed,
-                    "Green" => KeywordAbility.ProtectionFromGreen,
-                    _ => KeywordAbility.None
-                };
-            }
+
         
         public virtual void ResolveEffectOnPlayer(Player caster, Player targetPlayer)
         {

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -990,18 +990,7 @@ public class TurnSystem : MonoBehaviour
                 return false;
             }
         
-        private KeywordAbility GetProtectionKeyword(string color)
-            {
-                return color switch
-                {
-                    "White" => KeywordAbility.ProtectionFromWhite,
-                    "Blue" => KeywordAbility.ProtectionFromBlue,
-                    "Black" => KeywordAbility.ProtectionFromBlack,
-                    "Red" => KeywordAbility.ProtectionFromRed,
-                    "Green" => KeywordAbility.ProtectionFromGreen,
-                    _ => KeywordAbility.None
-                };
-            }
+
 
         private bool BlockerCanBlockAttacker(CreatureCard blocker, CreatureCard attacker, Player defender)
             {
@@ -1020,7 +1009,7 @@ public class TurnSystem : MonoBehaviour
                 if (IsLandwalkPreventingBlock(attacker, defender))
                     return false;
 
-                if (blocker.color.Any(c => attacker.keywordAbilities.Contains(GetProtectionKeyword(c))))
+                if (blocker.color.Any(c => attacker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c))))
                     return false;
 
                 return true;


### PR DESCRIPTION
## Summary
- add `ProtectionUtils` helper with `GetProtectionKeyword`
- use the helper in `GameManager`, `TurnSystem`, `SorceryCard`, and `CardVisual`
- remove duplicated methods

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863eef0c65483278d573249c70e3fd5