### PR TITLE
Refactor SpendFromPool to shared ManaPool method

### DIFF
--- a/Assets/Scripts/ArtifactCard.cs
+++ b/Assets/Scripts/ArtifactCard.cs
@@ -38,11 +38,11 @@ public class ArtifactCard : Card
                         remaining -= useColorless;
 
                         // 2. Spend colored mana in WUBRG order
-                        remaining -= SpendFromPool(ref owner.ColoredMana.White, remaining);
-                        remaining -= SpendFromPool(ref owner.ColoredMana.Blue, remaining);
-                        remaining -= SpendFromPool(ref owner.ColoredMana.Black, remaining);
-                        remaining -= SpendFromPool(ref owner.ColoredMana.Red, remaining);
-                        remaining -= SpendFromPool(ref owner.ColoredMana.Green, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.White, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Blue, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Black, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Red, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Green, remaining);
 
                         if (remaining > 0)
                         {
@@ -64,11 +64,5 @@ public class ArtifactCard : Card
         GameManager.Instance.UpdateUI();
     }
 
-    private int SpendFromPool(ref int pool, int needed)
-        {
-            int spent = Mathf.Min(pool, needed);
-            pool -= spent;
-            return spent;
-        }
 
 }

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -731,11 +731,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         remaining -= useColorless;
 
                         // Spend from WUBRG
-                        remaining -= SpendFromPool(ref player.ColoredMana.White, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Blue, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Black, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Red, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Green, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.White, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Blue, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Black, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Red, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Green, remaining);
 
                         if (remaining > 0)
                         {
@@ -836,11 +836,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                             remaining -= useColorless;
 
                             // Spend from WUBRG
-                            remaining -= SpendFromPool(ref player.ColoredMana.White, remaining);
-                            remaining -= SpendFromPool(ref player.ColoredMana.Blue, remaining);
-                            remaining -= SpendFromPool(ref player.ColoredMana.Black, remaining);
-                            remaining -= SpendFromPool(ref player.ColoredMana.Red, remaining);
-                            remaining -= SpendFromPool(ref player.ColoredMana.Green, remaining);
+                            remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.White, remaining);
+                            remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Blue, remaining);
+                            remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Black, remaining);
+                            remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Red, remaining);
+                            remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Green, remaining);
 
                             if (remaining > 0)
                             {
@@ -997,11 +997,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         remaining -= useColorless;
 
                         // 2. Spend from WUBRG
-                        remaining -= SpendFromPool(ref player.ColoredMana.White, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Blue, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Black, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Red, remaining);
-                        remaining -= SpendFromPool(ref player.ColoredMana.Green, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.White, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Blue, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Black, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Red, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Green, remaining);
 
                         if (remaining > 0)
                         {
@@ -1531,12 +1531,6 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     highlightBorder.SetActive(enable);
             }
 
-        private int SpendFromPool(ref int pool, int needed)
-            {
-                int spent = Mathf.Min(pool, needed);
-                pool -= spent;
-                return spent;
-            }
         
         private Sprite GetIconForColor(string color)
             {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -901,11 +901,11 @@ public class GameManager : MonoBehaviour
             remaining -= useColorless;
 
             // Spend from WUBRG
-            remaining -= SpendFromPool(ref owner.ColoredMana.White, remaining);
-            remaining -= SpendFromPool(ref owner.ColoredMana.Blue, remaining);
-            remaining -= SpendFromPool(ref owner.ColoredMana.Black, remaining);
-            remaining -= SpendFromPool(ref owner.ColoredMana.Red, remaining);
-            remaining -= SpendFromPool(ref owner.ColoredMana.Green, remaining);
+            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.White, remaining);
+            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Blue, remaining);
+            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Black, remaining);
+            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Red, remaining);
+            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Green, remaining);
 
             if (remaining > 0)
             {
@@ -1232,12 +1232,12 @@ public class GameManager : MonoBehaviour
                     Player controller = targetingPlayer;
                     int remaining = targetingArtifact.manaToPayToActivate;
 
-                    remaining -= SpendFromPool(ref controller.ColoredMana.Colorless, remaining);
-                    remaining -= SpendFromPool(ref controller.ColoredMana.White, remaining);
-                    remaining -= SpendFromPool(ref controller.ColoredMana.Blue, remaining);
-                    remaining -= SpendFromPool(ref controller.ColoredMana.Black, remaining);
-                    remaining -= SpendFromPool(ref controller.ColoredMana.Red, remaining);
-                    remaining -= SpendFromPool(ref controller.ColoredMana.Green, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Colorless, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.White, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Blue, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Black, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Red, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Green, remaining);
 
                     if (remaining > 0)
                     {
@@ -1278,12 +1278,12 @@ public class GameManager : MonoBehaviour
                 Player controller = targetingPlayer;
                 int remaining = targetingArtifact.manaToPayToActivate;
 
-                remaining -= SpendFromPool(ref controller.ColoredMana.Colorless, remaining);
-                remaining -= SpendFromPool(ref controller.ColoredMana.White, remaining);
-                remaining -= SpendFromPool(ref controller.ColoredMana.Blue, remaining);
-                remaining -= SpendFromPool(ref controller.ColoredMana.Black, remaining);
-                remaining -= SpendFromPool(ref controller.ColoredMana.Red, remaining);
-                remaining -= SpendFromPool(ref controller.ColoredMana.Green, remaining);
+                remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Colorless, remaining);
+                remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.White, remaining);
+                remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Blue, remaining);
+                remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Black, remaining);
+                remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Red, remaining);
+                remaining -= Player.ManaPool.SpendFromPool(ref controller.ColoredMana.Green, remaining);
 
                 if (remaining > 0)
                 {
@@ -1525,12 +1525,6 @@ public class GameManager : MonoBehaviour
             return breakdown;
         }
 
-    private int SpendFromPool(ref int pool, int needed)
-        {
-            int spent = Mathf.Min(pool, needed);
-            pool -= spent;
-            return spent;
-        }
 
     public void BeginTargetingWithArtifactDamage(ArtifactCard artifact, Player player, CardVisual visual)
     {

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -118,6 +118,13 @@ public class Player
                     Debug.LogWarning("Tried to spend more generic mana than available. This should not happen if CanPay() was used.");
                 }
             }
+
+        public static int SpendFromPool(ref int pool, int needed)
+            {
+                int spent = Mathf.Min(pool, needed);
+                pool -= spent;
+                return spent;
+            }
         }
 
     public void PlayCard(Card card)

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1102,12 +1102,6 @@ public class TurnSystem : MonoBehaviour
                 RunCurrentPhase();
             }
         
-        private int SpendFromPool(ref int pool, int needed)
-            {
-                int spent = Mathf.Min(pool, needed);
-                pool -= spent;
-                return spent;
-            }
         
         private IEnumerator WaitToShowCombatDamage()
             {


### PR DESCRIPTION
## Summary
- centralize `SpendFromPool` by adding it to `Player.ManaPool`
- use the new shared method throughout the codebase
- remove duplicated helper methods

## Testing
- `echo "No tests specified"`

------
https://chatgpt.com/codex/tasks/task_e_6863f277e1a8832794d4b78e7635796d