### PR TITLE
Add flavor text support

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -16,6 +16,7 @@ public class Card
     public string PrimaryColor => color.Count > 0 ? color[0] : "None";
 
     public string rulesText;
+    public string flavorText;
 
     public int plagueAmount;
     public int manaToGain;
@@ -258,6 +259,9 @@ public class Card
                 if (keywordAbilities.Contains(KeywordAbility.BeastCreatureSpellsCostOneLess))
                     lines.Add("Beast creature spells you cast cost 1 less.");
             }
+
+            if (!string.IsNullOrEmpty(flavorText))
+                lines.Add($"<i>{flavorText}</i>");
 
             return string.Join("\n", lines);
         }

--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -18,6 +18,7 @@ public class CardData
     public string requiredTargetColor = null;
 
     public string rulesText;
+    public string flavorText;
 
     public bool entersTapped = false;
     public bool isToken = false;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -339,6 +339,7 @@ public static class CardDatabase
                     toughness = 0,
                     subtypes = new List<string> { "Horse" },
                     rulesText = "This creature has power and toughness equal to the number of Plains you control.",
+                    flavorText = "A symbol of hope galloping through untouched meadows.",
                     keywordAbilities = new List<KeywordAbility>
                     {
                         KeywordAbility.Vigilance,

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -104,6 +104,7 @@ public static class CardFactory
         newCard.entersTapped = data.entersTapped;
         newCard.abilities = new List<CardAbility>(data.abilities);
         newCard.rulesText = data.rulesText;
+        newCard.flavorText = data.flavorText;
         newCard.isToken = data.isToken;
 
         Debug.Log($"{newCard.cardName} created with {newCard.abilities.Count} abilities.");

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1534,6 +1534,13 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
                 rules += $"Destroy target {destroyType}.\n";
             }
+            rules = rules.TrimEnd();
+            if (!string.IsNullOrEmpty(sorcery.flavorText))
+            {
+                if (!string.IsNullOrEmpty(rules))
+                    rules += "\n";
+                rules += $"<i>{sorcery.flavorText}</i>";
+            }
             keywordText.text = rules.Trim();
             }
 


### PR DESCRIPTION
## Summary
- support optional flavor text for each card
- show flavor text in italic under rules text
- example flavor text for Untamed Unicorn

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68667e85a3408327a7f80c9163ba49ba