### PR TITLE
Make stack cards non-interactable

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -62,6 +62,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
     public bool isInBattlefield = false;
     public bool isInGraveyard = false;
+    public bool isInStack = false; // when true, card is on the stack
 
     void Start()
         {
@@ -70,7 +71,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
     public void OnPointerEnter(PointerEventData eventData)
         {
-            if (isInGraveyard || linkedCard == null || linkedCard.artwork == null)
+            if (isInGraveyard || isInStack || linkedCard == null || linkedCard.artwork == null)
                 return;
 
             CardHoverPreview.Instance.ShowCard(linkedCard);
@@ -91,7 +92,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
         public void OnPointerExit(PointerEventData eventData)
         {
-            if (isInGraveyard)
+            if (isInGraveyard || isInStack)
                 return;
 
             CardHoverPreview.Instance.HidePreview();
@@ -414,6 +415,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
         {
             linkedCard = card;
             gameManager = manager;
+            isInStack = false;
 
             UpdateLandIcon();
 
@@ -533,6 +535,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
     public void OnClick()
         {
+            if (isInStack)
+                return;
             // Optional ETB targeting (e.g. Monk: "You may destroy target artifact")
             if (GameManager.Instance.targetingCreatureOptional != null)
             {
@@ -1215,6 +1219,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
         {
             isInBattlefield = false;
             isInGraveyard = true;
+            isInStack = false;
 
             if (lineRenderer != null)
                 lineRenderer.enabled = false;
@@ -1234,6 +1239,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
         {
             isInBattlefield = false;
             isInGraveyard = true;
+            isInStack = false;
 
             // Re-enable UI components in case they were disabled on battlefield
             if (backgroundImage != null) backgroundImage.enabled = true;
@@ -1258,6 +1264,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             // General setup
             isInBattlefield = false;
             isInGraveyard = true;
+            isInStack = false;
 
             CardData cardData = CardDatabase.GetCardData(linkedCard.cardName);
             if (cardData != null && cardTypeText != null)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -286,6 +286,7 @@ public class GameManager : MonoBehaviour
 
                     // Move visual to the stack zone
                     visual.transform.SetParent(stackZone, false);
+                    visual.isInStack = true;
                     visual.transform.localPosition = Vector3.zero;
                     visual.transform.localRotation = Quaternion.identity;
                     visual.transform.localScale = Vector3.one;
@@ -1421,6 +1422,7 @@ public class GameManager : MonoBehaviour
                 Debug.Log($"Target selected: {chosen.cardName}");
 
                 targetingVisual.transform.SetParent(stackZone, false);
+                targetingVisual.isInStack = true;
                 targetingVisual.transform.localPosition = Vector3.zero;
                 targetingVisual.transform.localRotation = Quaternion.identity;
                 targetingVisual.transform.localScale = Vector3.one;
@@ -1476,6 +1478,7 @@ public class GameManager : MonoBehaviour
 
             // Move visual to stack
             targetingVisual.transform.SetParent(stackZone, false);
+            targetingVisual.isInStack = true;
             targetingVisual.transform.localPosition = Vector3.zero;
             targetingVisual.transform.localRotation = Quaternion.identity;
             targetingVisual.transform.localScale = Vector3.one;

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -527,6 +527,7 @@ public class TurnSystem : MonoBehaviour
 
                                         visual.transform.localPosition = Vector3.zero;
                                         visual.transform.SetParent(GameManager.Instance.stackZone, false);
+                                        visual.isInStack = true;
 
                                         GameManager.Instance.UpdateUI();
                                         SoundManager.Instance.PlaySound(SoundManager.Instance.cardPlay);


### PR DESCRIPTION
## Summary
- add `isInStack` property to `CardVisual`
- skip hover effects and clicks for cards on stack
- mark visuals as on stack when moved to the stack zone

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6866c901f0a48327be804818005a9fff