### PR TITLE
Add delay when AI ends turn

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -953,7 +953,12 @@ public class TurnSystem : MonoBehaviour
                     }
                     else
                     {
-                        BeginTurn(currentPlayer == PlayerType.Human ? PlayerType.AI : PlayerType.Human);
+                        PlayerType nextPlayer = currentPlayer == PlayerType.Human ? PlayerType.AI : PlayerType.Human;
+
+                        if (currentPlayer == PlayerType.AI)
+                            StartCoroutine(BeginTurnAfterDelay(nextPlayer));
+                        else
+                            BeginTurn(nextPlayer);
                     }
                     break;
             }
@@ -1125,6 +1130,12 @@ public class TurnSystem : MonoBehaviour
 
 
                 damageCoroutine = null;
+            }
+
+        private IEnumerator BeginTurnAfterDelay(PlayerType player)
+            {
+                yield return new WaitForSeconds(1f);
+                BeginTurn(player);
             }
 
         private Player.ManaPool GetPotentialManaPool(Player ai)


### PR DESCRIPTION
## Summary
- delay the start of the human player's turn by 1s after the AI ends its turn

## Testing
- `# No tests provided in repository`

------
https://chatgpt.com/codex/tasks/task_e_6866cd6116608327bd77dd94937826e6