### PR TITLE
Batch draw sound improvements

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1027,10 +1027,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                             return;
                         }
 
-                        for (int i = 0; i < artifact.cardsToDraw; i++)
-                        {
-                            GameManager.Instance.DrawCard(player);
-                        }
+                        GameManager.Instance.DrawCards(player, artifact.cardsToDraw);
 
                         SoundManager.Instance.PlaySound(SoundManager.Instance.drink);
                         linkedCard.isTapped = true;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -105,11 +105,8 @@ public class GameManager : MonoBehaviour
         ShuffleDeck(humanPlayer);
         ShuffleDeck(aiPlayer);
 
-        for (int i = 0; i < 7; i++)
-        {
-            DrawCard(humanPlayer);
-            DrawCard(aiPlayer);
-        }
+        DrawCards(humanPlayer, 7);
+        DrawCards(aiPlayer, 7);
     }
 
     void Update()
@@ -144,7 +141,20 @@ public class GameManager : MonoBehaviour
             player.Deck[randomIndex] = temp;
         }
     }
-    public void DrawCard(Player player)
+
+    public void DrawCards(Player player, int amount)
+    {
+        if (amount <= 0)
+            return;
+
+        for (int i = 0; i < amount; i++)
+        {
+            // only play the draw sound on the first card if this is the human player
+            bool playSfx = (i == 0);
+            DrawCard(player, playSfx);
+        }
+    }
+    public void DrawCard(Player player, bool playSfx = true)
     {
         if (player.Deck.Count == 0)
         {
@@ -177,7 +187,10 @@ public class GameManager : MonoBehaviour
         }
 
         NotifyCardDrawn(player, 1);
-        SoundManager.Instance.PlaySound(SoundManager.Instance.drawCard);
+        if (player == humanPlayer && playSfx)
+        {
+            SoundManager.Instance.PlaySound(SoundManager.Instance.drawCard);
+        }
     }
 
     public void PlayCard(Player player, CardVisual visual)

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -124,9 +124,7 @@ public class SorceryCard : Card
             }
             if (cardsToDraw > 0)
                 {
-                    for (int i = 0; i < cardsToDraw; i++)
-                        GameManager.Instance.DrawCard(caster);
-
+                    GameManager.Instance.DrawCards(caster, cardsToDraw);
                     Debug.Log($"{caster} draws {cardsToDraw} card(s).");
                     didSomething = true;
                 }

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -686,10 +686,7 @@ public class TurnSystem : MonoBehaviour
                                         ai.ColoredMana.Pay(abilityCost);
                                         artifact.isTapped = true;
 
-                                        for (int i = 0; i < artifact.cardsToDraw; i++)
-                                        {
-                                            GameManager.Instance.DrawCard(ai);
-                                        }
+                                        GameManager.Instance.DrawCards(ai, artifact.cardsToDraw);
 
                                         GameManager.Instance.SendToGraveyard(artifact, ai);
                                         Debug.Log($"AI sacrifices {artifact.cardName} to draw {artifact.cardsToDraw} card(s).");


### PR DESCRIPTION
## Summary
- only play draw card sound once when player draws multiple cards
- skip draw card sound for AI
- update card draw abilities to use new `DrawCards` helper

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867143dbb888327bf6a49afde9b73ac