### PR TITLE
Prevent phase progression after game over

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -63,6 +63,7 @@ public class GameManager : MonoBehaviour
     public Dictionary<CreatureCard, List<CreatureCard>> blockingAssignments = new Dictionary<CreatureCard, List<CreatureCard>>();
 
     public bool isStackBusy = false;
+    public bool gameOver = false;
 
     public SorceryCard targetingSorcery;
     public Player targetingPlayer;
@@ -116,6 +117,7 @@ public class GameManager : MonoBehaviour
             if (!string.IsNullOrEmpty(BattleData.CurrentZoneId))
             {
                 Debug.Log("[DEV] Instant win triggered for zone ID: " + BattleData.CurrentZoneId);
+                gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowWinScreen();
             }
             else
@@ -161,11 +163,13 @@ public class GameManager : MonoBehaviour
             if (player == aiPlayer)
             {
                 Debug.Log("AI tried to draw from an empty deck — player wins by mill.");
+                gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowWinScreen();
             }
             else if (player == humanPlayer)
             {
                 Debug.Log("Player tried to draw from an empty deck — player loses by mill.");
+                gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowLoseScreen();
             }
             return;
@@ -2281,11 +2285,13 @@ public class GameManager : MonoBehaviour
             if (aiPlayer.Life <= 0)
             {
                 Debug.Log("AI defeated — player wins!");
+                gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowWinScreen();
             }
             else if (humanPlayer.Life <= 0)
             {
                 Debug.Log("Human player defeated — game lost.");
+                gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowLoseScreen();
             }
         }

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -71,6 +71,9 @@ public class TurnSystem : MonoBehaviour
 
     void Update()
         {
+            if (GameManager.Instance.gameOver)
+                return;
+
             if (currentPlayer == PlayerType.AI && !waitingForPlayerInput && !GameManager.Instance.isStackBusy)
             {
                 RunCurrentPhase();
@@ -111,6 +114,9 @@ public class TurnSystem : MonoBehaviour
 
     public void NextPhaseButton()
         {
+            if (GameManager.Instance.gameOver)
+                return;
+
             if (currentPlayer == PlayerType.Human && waitingForPlayerInput)
             {
                 SoundManager.Instance.PlaySound(SoundManager.Instance.buttonClick);
@@ -178,6 +184,9 @@ public class TurnSystem : MonoBehaviour
 
     public void BeginTurn(PlayerType player)
         {
+            if (GameManager.Instance.gameOver)
+                return;
+
             currentPlayer = player;
             currentPhase = TurnPhase.StartTurn;
             Debug.Log($"\n=== {player} TURN START ===");
@@ -186,6 +195,9 @@ public class TurnSystem : MonoBehaviour
 
     void AdvancePhase()
         {
+            if (GameManager.Instance.gameOver)
+                return;
+
             GameManager.Instance.UpdateUI();
 
             // Empty mana at the end of each phase
@@ -204,6 +216,9 @@ public class TurnSystem : MonoBehaviour
 
     void RunCurrentPhase()
         {
+            if (GameManager.Instance.gameOver)
+                return;
+
             Debug.Log($"[Phase] {currentPlayer} - {currentPhase}");
 
             if (GameManager.Instance.isStackBusy)
@@ -959,11 +974,12 @@ public class TurnSystem : MonoBehaviour
         private IEnumerator WaitAndAdvancePhase()
             {
                 yield return new WaitUntil(() => !GameManager.Instance.isStackBusy);
-                
+
                 // Wait a frame to ensure any triggered UI changes or effects have finished
                 yield return null;
 
-                AdvancePhase(); // <-- This must always be called
+                if (!GameManager.Instance.gameOver)
+                    AdvancePhase(); // <-- This must always be called
             }
         
         private bool IsLandwalkPreventingBlock(CreatureCard attacker, Player defender)

--- a/Assets/Scripts/WinScreenUI.cs
+++ b/Assets/Scripts/WinScreenUI.cs
@@ -31,6 +31,9 @@ public class WinScreenUI : MonoBehaviour
         if (winIconImage != null && winSprite != null)
             winIconImage.sprite = winSprite;
 
+        if (GameManager.Instance != null)
+            GameManager.Instance.gameOver = true;
+
         SoundManager.Instance.PlaySound(SoundManager.Instance.victory);
 
         StartCoroutine(FadeIn());
@@ -41,6 +44,9 @@ public class WinScreenUI : MonoBehaviour
         isWin = false;
         if (winIconImage != null && loseSprite != null)
             winIconImage.sprite = loseSprite;
+
+        if (GameManager.Instance != null)
+            GameManager.Instance.gameOver = true;
 
         SoundManager.Instance.PlaySound(SoundManager.Instance.defeat);
 


### PR DESCRIPTION
## Summary
- add a `gameOver` flag to `GameManager`
- set `gameOver` when win/lose screens are shown
- skip turn system updates and phase advancement when the game is over

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68679583b38883279c391158e7a35024