### PR TITLE
Add Heavy Taxation enchantment

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -265,6 +265,8 @@ public class Card
                     lines.Add("Creature spells you cast cost 1 less.");
                 if (keywordAbilities.Contains(KeywordAbility.BeastCreatureSpellsCostOneLess))
                     lines.Add("Beast creature spells you cast cost 1 less.");
+                if (keywordAbilities.Contains(KeywordAbility.OpponentSpellsCostOneMore))
+                    lines.Add("Spells cast by your opponent cost 1 more.");
             }
 
             if (!string.IsNullOrEmpty(flavorText))

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2770,6 +2770,20 @@ public static class CardDatabase
                             }
                         }
                     });
+
+                Add(new CardData //Heavy Taxation
+                    {
+                        cardName = "Heavy Taxation",
+                        rarity = "Rare",
+                        manaCost = 4,
+                        color = new List<string> { "White" },
+                        cardType = CardType.Enchantment,
+                        artwork = Resources.Load<Sprite>("Art/heavy_taxation"),
+                        keywordAbilities = new List<KeywordAbility>
+                        {
+                            KeywordAbility.OpponentSpellsCostOneMore
+                        }
+                    });
             }
 
     private static void Add(CardData data)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -249,6 +249,13 @@ public class GameManager : MonoBehaviour
             else if (card is CreatureCard creature)
             {
                 var cost = GetManaCostBreakdown(card.manaCost, card.color);
+                int tax = GetOpponentSpellTax(player);
+                if (tax > 0)
+                {
+                    if (!cost.ContainsKey("Colorless"))
+                        cost["Colorless"] = 0;
+                    cost["Colorless"] += tax;
+                }
                 int reduction = GetCreatureCostReduction(player);
                 CardData data = CardDatabase.GetCardData(card.cardName);
                 if (data != null && data.subtypes.Contains("Beast"))
@@ -299,6 +306,13 @@ public class GameManager : MonoBehaviour
                 }
 
                 var cost = GetManaCostBreakdown(sorcery.manaCost, sorcery.color);
+                int tax = GetOpponentSpellTax(player);
+                if (tax > 0)
+                {
+                    if (!cost.ContainsKey("Colorless"))
+                        cost["Colorless"] = 0;
+                    cost["Colorless"] += tax;
+                }
                 if (player.ColoredMana.CanPay(cost))
                 {
                     isStackBusy = true; // BLOCK OTHER ACTIONS WHILE SORCERY IS ON STACK
@@ -324,6 +338,13 @@ public class GameManager : MonoBehaviour
             else if (card is ArtifactCard artifact)
             {
                 var cost = GetManaCostBreakdown(artifact.manaCost, artifact.color);
+                int tax = GetOpponentSpellTax(player);
+                if (tax > 0)
+                {
+                    if (!cost.ContainsKey("Colorless"))
+                        cost["Colorless"] = 0;
+                    cost["Colorless"] += tax;
+                }
                 if (player.ColoredMana.CanPay(cost))
                 {
                     player.ColoredMana.Pay(cost);
@@ -360,6 +381,13 @@ public class GameManager : MonoBehaviour
             else if (card is EnchantmentCard enchantment)
             {
                 var cost = GetManaCostBreakdown(enchantment.manaCost, enchantment.color);
+                int tax = GetOpponentSpellTax(player);
+                if (tax > 0)
+                {
+                    if (!cost.ContainsKey("Colorless"))
+                        cost["Colorless"] = 0;
+                    cost["Colorless"] += tax;
+                }
                 if (player.ColoredMana.CanPay(cost))
                 {
                     player.ColoredMana.Pay(cost);
@@ -1252,6 +1280,13 @@ public class GameManager : MonoBehaviour
             card.keywordAbilities.Contains(KeywordAbility.BeastCreatureSpellsCostOneLess));
     }
 
+    public int GetOpponentSpellTax(Player player)
+    {
+        Player opponent = GetOpponentOf(player);
+        return opponent.Battlefield.Count(card => card.keywordAbilities != null &&
+            card.keywordAbilities.Contains(KeywordAbility.OpponentSpellsCostOneMore));
+    }
+
     public void TryGainLife(Player player, int amount)
     {
         if (amount <= 0 || IsLifeGainPrevented())
@@ -1503,6 +1538,13 @@ public class GameManager : MonoBehaviour
 
                 // Pay mana before resolving
                 var cost = GetManaCostBreakdown(targetingSorcery.manaCost, targetingSorcery.color);
+                int tax = GetOpponentSpellTax(targetingPlayer);
+                if (tax > 0)
+                {
+                    if (!cost.ContainsKey("Colorless"))
+                        cost["Colorless"] = 0;
+                    cost["Colorless"] += tax;
+                }
                 if (!targetingPlayer.ColoredMana.CanPay(cost))
                 {
                     Debug.LogWarning("Not enough mana to cast targeted sorcery.");

--- a/Assets/Scripts/KeywordAbility.cs
+++ b/Assets/Scripts/KeywordAbility.cs
@@ -27,6 +27,7 @@ public enum KeywordAbility
     OnlyCastCreatureSpells,
     CreatureSpellsCostOneLess,
     BeastCreatureSpellsCostOneLess,
+    OpponentSpellsCostOneMore,
 }
 
 public enum ActivatedAbility

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -353,6 +353,13 @@ public class TurnSystem : MonoBehaviour
                                 if (card is CreatureCard creature)
                                 {
                                     var cost = GameManager.Instance.GetManaCostBreakdown(creature.manaCost, creature.color);
+                                    int tax = GameManager.Instance.GetOpponentSpellTax(ai);
+                                    if (tax > 0)
+                                    {
+                                        if (!cost.ContainsKey("Colorless"))
+                                            cost["Colorless"] = 0;
+                                        cost["Colorless"] += tax;
+                                    }
                                     int reduction = GameManager.Instance.GetCreatureCostReduction(ai);
                                     CardData data = CardDatabase.GetCardData(creature.cardName);
                                     if (data != null && data.subtypes.Contains("Beast"))
@@ -419,6 +426,13 @@ public class TurnSystem : MonoBehaviour
                                 else if (card is SorceryCard sorcery)
                                 {
                                     var cost = GameManager.Instance.GetManaCostBreakdown(sorcery.manaCost, sorcery.color);
+                                    int tax = GameManager.Instance.GetOpponentSpellTax(ai);
+                                    if (tax > 0)
+                                    {
+                                        if (!cost.ContainsKey("Colorless"))
+                                            cost["Colorless"] = 0;
+                                        cost["Colorless"] += tax;
+                                    }
                                     if (EnsureManaForCost(ai, cost))
                                     {
                                         if (sorcery.requiredTargetType == SorceryCard.TargetType.Creature &&
@@ -560,6 +574,13 @@ public class TurnSystem : MonoBehaviour
                                 else if (card is ArtifactCard artifact)
                                 {
                                     var cost = GameManager.Instance.GetManaCostBreakdown(artifact.manaCost, artifact.color);
+                                    int tax = GameManager.Instance.GetOpponentSpellTax(ai);
+                                    if (tax > 0)
+                                    {
+                                        if (!cost.ContainsKey("Colorless"))
+                                            cost["Colorless"] = 0;
+                                        cost["Colorless"] += tax;
+                                    }
                                     if (EnsureManaForCost(ai, cost))
                                     {
                                         ai.ColoredMana.Pay(cost);
@@ -588,6 +609,13 @@ public class TurnSystem : MonoBehaviour
                                 else if (card is EnchantmentCard enchantment)
                                 {
                                     var cost = GameManager.Instance.GetManaCostBreakdown(enchantment.manaCost, enchantment.color);
+                                    int tax = GameManager.Instance.GetOpponentSpellTax(ai);
+                                    if (tax > 0)
+                                    {
+                                        if (!cost.ContainsKey("Colorless"))
+                                            cost["Colorless"] = 0;
+                                        cost["Colorless"] += tax;
+                                    }
                                     if (EnsureManaForCost(ai, cost))
                                     {
                                         ai.ColoredMana.Pay(cost);


### PR DESCRIPTION
## Summary
- introduce `OpponentSpellsCostOneMore` keyword ability
- implement cost increase checks for both players and AI
- display the ability text on cards
- add `Heavy Taxation` rare white enchantment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fd8ed9908327b0dbcc0f898eaf69