### PR TITLE
Add Headeache enchantment with discard trigger

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -247,6 +247,8 @@ public class Card
                     lines.Add("Whenever an opponent draws a card, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnCreatureDiesOrDiscarded)
                     lines.Add("Whenever a creature dies or is discarded, " + ability.description);
+                else if (ability.timing == TriggerTiming.OnPlayerDiscard)
+                    lines.Add("Whenever a player discards a card, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnCombatDamageToPlayer)
                     lines.Add("Whenever a creature deals combat damage to a player, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnOpponentDiscard)

--- a/Assets/Scripts/CardAbility.cs
+++ b/Assets/Scripts/CardAbility.cs
@@ -11,6 +11,7 @@ public enum TriggerTiming
     OnCardDraw,
     OnOpponentDraw,
     OnCreatureDiesOrDiscarded,
+    OnPlayerDiscard,
     OnOpponentDiscard,
     OnCombatDamageToPlayer,
 }

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2784,6 +2784,38 @@ public static class CardDatabase
                             KeywordAbility.OpponentSpellsCostOneMore
                         }
                     });
+
+                Add(new CardData //Headeache
+                    {
+                        cardName = "Headeache",
+                        rarity = "Uncommon",
+                        manaCost = 2,
+                        color = new List<string> { "Red" },
+                        cardType = CardType.Enchantment,
+                        artwork = Resources.Load<Sprite>("Art/headeache"),
+                        abilities = new List<CardAbility>
+                        {
+                            new CardAbility
+                            {
+                                timing = TriggerTiming.OnPlayerDiscard,
+                                description = "that player takes 1 damage.",
+                                effect = (Player owner, Card selfCard) =>
+                                {
+                                    Player target = GameManager.Instance.lastDiscardingPlayer;
+                                    if (target != null)
+                                    {
+                                        target.Life -= 1;
+                                        GameObject ui = target == GameManager.Instance.humanPlayer ?
+                                            GameManager.Instance.playerLifeContainer :
+                                            GameManager.Instance.enemyLifeContainer;
+                                        GameManager.Instance.ShowFloatingDamage(1, ui);
+                                        GameManager.Instance.UpdateUI();
+                                        GameManager.Instance.CheckForGameEnd();
+                                    }
+                                }
+                            }
+                        }
+                    });
             }
 
     private static void Add(CardData data)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -535,7 +535,10 @@ public class GameManager : MonoBehaviour
             owner.Hand.Remove(card);
 
             if (discardedFromHand)
+            {
                 NotifyOpponentDiscard(owner);
+                NotifyPlayerDiscard(owner);
+            }
 
             Debug.Log($"{card.cardName} is being sent to the graveyard.");
 
@@ -2353,6 +2356,8 @@ public class GameManager : MonoBehaviour
 
         public int lastCardsDrawnAmount = 0;
 
+        public Player lastDiscardingPlayer = null;
+
         public void NotifyCardDrawn(Player player, int amount)
         {
             lastCardsDrawnAmount = amount;
@@ -2407,6 +2412,25 @@ public class GameManager : MonoBehaviour
                     }
                 }
             }
+        }
+
+        public void NotifyPlayerDiscard(Player discardingPlayer)
+        {
+            lastDiscardingPlayer = discardingPlayer;
+            foreach (var player in new[] { humanPlayer, aiPlayer })
+            {
+                foreach (var card in player.Battlefield.ToList())
+                {
+                    foreach (var ability in card.abilities)
+                    {
+                        if (ability.timing == TriggerTiming.OnPlayerDiscard && ability.effect != null)
+                        {
+                            ability.effect.Invoke(player, card);
+                        }
+                    }
+                }
+            }
+            lastDiscardingPlayer = null;
         }
 
         public void NotifyCreatureDiesOrDiscarded(Card creature, Player owner)


### PR DESCRIPTION
## Summary
- support new trigger timing `OnPlayerDiscard`
- show text for the new trigger type
- emit events when any player discards a card
- introduce red enchantment **Headeache** dealing damage to whoever discards a card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686910461b548327a54419e05ed064c3