### PR TITLE
Add Veilbreaker Druid card

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -1528,6 +1528,33 @@ public static class CardDatabase
                     flavorText = "They’ve learned which bones snap easiest. And they enjoy the sound.",
                     artwork = Resources.Load<Sprite>("Art/violent_ape")
                     });
+                Add(new CardData //Veilbreaker Druid
+                    {
+                    cardName = "Veilbreaker Druid",
+                    rarity = "Common",
+                    manaCost = 3,
+                    color = new List<string> { "Green" },
+                    cardType = CardType.Creature,
+                    power = 2,
+                    toughness = 2,
+                    subtypes = new List<string> { "Human", "Druid" },
+                    artwork = Resources.Load<Sprite>("Art/veilbreaker_druid"),
+                    abilities = new List<CardAbility>
+                    {
+                        new CardAbility
+                        {
+                            timing = TriggerTiming.OnEnter,
+                            description = ", you may destroy target enchantment.",
+                            requiresTarget = true,
+                            requiredTargetType = SorceryCard.TargetType.Enchantment,
+                            effect = (Player owner, Card target) =>
+                            {
+                                Player controller = GameManager.Instance.GetOwnerOfCard(target);
+                                GameManager.Instance.SendToGraveyard(target, controller);
+                            }
+                        }
+                    }
+                    });
                 Add(new CardData //Flying donkey
                     {
                     cardName = "Flying Donkey",

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -566,6 +566,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 if (ability.requiredTargetType == SorceryCard.TargetType.Artifact && clicked is ArtifactCard)
                     isValid = true;
 
+                if (ability.requiredTargetType == SorceryCard.TargetType.Enchantment && clicked is EnchantmentCard)
+                    isValid = true;
+
                 if (ability.requiredTargetType == SorceryCard.TargetType.Land && clicked is LandCard)
                     isValid = true;
 
@@ -636,6 +639,12 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 }
 
                 if (spell.requiredTargetType == SorceryCard.TargetType.Artifact && card is ArtifactCard)
+                {
+                    if (GameManager.Instance.GetOwnerOfCard(card).Battlefield.Contains(card))
+                        valid = true;
+                }
+
+                if (spell.requiredTargetType == SorceryCard.TargetType.Enchantment && card is EnchantmentCard)
                 {
                     if (GameManager.Instance.GetOwnerOfCard(card).Battlefield.Contains(card))
                         valid = true;
@@ -1577,6 +1586,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     SorceryCard.PermanentTypeToDestroy.Land => "lands",
                     SorceryCard.PermanentTypeToDestroy.Creature => "creatures",
                     SorceryCard.PermanentTypeToDestroy.Artifact => "artifacts",
+                    SorceryCard.PermanentTypeToDestroy.Enchantment => "enchantments",
                     _ => "permanents"
                 };
                 rules += $"Destroy all {typeStr}.\n";
@@ -1596,6 +1606,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     SorceryCard.TargetType.Creature => "creature",
                     SorceryCard.TargetType.Land => "land",
                     SorceryCard.TargetType.Artifact => "non-creature artifact",
+                    SorceryCard.TargetType.Enchantment => "enchantment",
                     _ => "permanent"
                 };
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1364,6 +1364,7 @@ public class GameManager : MonoBehaviour
                     (sorcery.requiredTargetType == SorceryCard.TargetType.Creature && target is CreatureCard) ||
                     (sorcery.requiredTargetType == SorceryCard.TargetType.Land && target is LandCard) ||
                     (sorcery.requiredTargetType == SorceryCard.TargetType.Artifact && target is ArtifactCard) ||
+                    (sorcery.requiredTargetType == SorceryCard.TargetType.Enchantment && target is EnchantmentCard) ||
                     (sorcery.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer && target is CreatureCard);
 
                 bool isOnBattlefield = GetOwnerOfCard(target)?.Battlefield.Contains(target) == true;
@@ -1517,7 +1518,8 @@ public class GameManager : MonoBehaviour
                     (targetingAbility.requiredTargetType == SorceryCard.TargetType.Creature && target is CreatureCard creature &&
                         !(targetingAbility.excludeArtifactCreatures && creature.color.Contains("Artifact"))) ||
                     (targetingAbility.requiredTargetType == SorceryCard.TargetType.Land && target is LandCard) ||
-                    (targetingAbility.requiredTargetType == SorceryCard.TargetType.Artifact && target is ArtifactCard);
+                    (targetingAbility.requiredTargetType == SorceryCard.TargetType.Artifact && target is ArtifactCard) ||
+                    (targetingAbility.requiredTargetType == SorceryCard.TargetType.Enchantment && target is EnchantmentCard);
 
                 bool isOnBattlefield = GetOwnerOfCard(target)?.Battlefield.Contains(target) == true;
 
@@ -1550,6 +1552,7 @@ public class GameManager : MonoBehaviour
                         !(targetingSorcery.excludeArtifactCreatures && creatureT.color.Contains("Artifact"))) ||
                     (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Land && chosen is LandCard) ||
                     (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Artifact && chosen is ArtifactCard) ||
+                    (targetingSorcery.requiredTargetType == SorceryCard.TargetType.Enchantment && chosen is EnchantmentCard) ||
                     (targetingSorcery.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer && chosen is CreatureCard);
 
                 // Validate color
@@ -1802,6 +1805,7 @@ public class GameManager : MonoBehaviour
                 bool correctType =
                     (ability.requiredTargetType == SorceryCard.TargetType.Creature && target is CreatureCard) ||
                     (ability.requiredTargetType == SorceryCard.TargetType.Artifact && target is ArtifactCard) ||
+                    (ability.requiredTargetType == SorceryCard.TargetType.Enchantment && target is EnchantmentCard) ||
                     (ability.requiredTargetType == SorceryCard.TargetType.Land && target is LandCard);
 
                 bool isOnBattlefield = GetOwnerOfCard(target)?.Battlefield.Contains(target) == true;
@@ -1837,6 +1841,7 @@ public class GameManager : MonoBehaviour
                     bool correctType =
                         (ability.requiredTargetType == SorceryCard.TargetType.Creature && target is CreatureCard) ||
                         (ability.requiredTargetType == SorceryCard.TargetType.Artifact && target is ArtifactCard) ||
+                        (ability.requiredTargetType == SorceryCard.TargetType.Enchantment && target is EnchantmentCard) ||
                         (ability.requiredTargetType == SorceryCard.TargetType.Land && target is LandCard);
 
                     if (correctType)

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -37,6 +37,7 @@ public class SorceryCard : Card
         Creature,
         Land,
         Artifact,
+        Enchantment,
         Player,
         CreatureOrPlayer
     }
@@ -47,6 +48,7 @@ public class SorceryCard : Card
             Land,
             Creature,
             Artifact,
+            Enchantment,
             // Add more as needed later (Artifacts, Enchantments, etc.)
         }
 
@@ -200,6 +202,9 @@ public class SorceryCard : Card
                                             return true;
                                     }
                                 }
+
+                                if (typeOfPermanentToDestroyAll == PermanentTypeToDestroy.Enchantment && card is EnchantmentCard)
+                                    return true;
 
                                 return false;
                             })
@@ -356,7 +361,8 @@ public class SorceryCard : Card
                             (requiredTargetType == TargetType.Creature && target is CreatureCard targetCreature &&
                                 !(excludeArtifactCreatures && targetCreature.color.Contains("Artifact"))) ||
                             (requiredTargetType == TargetType.Land && target is LandCard) ||
-                            (requiredTargetType == TargetType.Artifact && target is ArtifactCard);
+                            (requiredTargetType == TargetType.Artifact && target is ArtifactCard) ||
+                            (requiredTargetType == TargetType.Enchantment && target is EnchantmentCard);
 
                         bool colorMatches = true;
 

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -394,6 +394,7 @@ public class TurnSystem : MonoBehaviour
                                                             (ability.requiredTargetType == SorceryCard.TargetType.Creature && c is CreatureCard creatureT &&
                                                                 !(ability.excludeArtifactCreatures && creatureT.color.Contains("Artifact"))) ||
                                                             (ability.requiredTargetType == SorceryCard.TargetType.Artifact && c is ArtifactCard) ||
+                                                            (ability.requiredTargetType == SorceryCard.TargetType.Enchantment && c is EnchantmentCard) ||
                                                             (ability.requiredTargetType == SorceryCard.TargetType.Land && c is LandCard))
                                                         .OrderByDescending(c => CardDatabase.GetCardData(c.cardName)?.manaCost ?? 0)
                                                         .FirstOrDefault();
@@ -477,7 +478,28 @@ public class TurnSystem : MonoBehaviour
                                             {
                                                 sorcery.chosenTarget = target;
                                                 sorcery.chosenPlayerTarget = null;
-                                                Debug.Log($"AI targets {target.cardName} with {sorcery.cardName} (highest cost artifact).");
+                                            Debug.Log($"AI targets {target.cardName} with {sorcery.cardName} (highest cost artifact).");
+                                            }
+                                        }
+                                        else if (sorcery.requiredTargetType == SorceryCard.TargetType.Enchantment &&
+                                                sorcery.destroyTargetIfTypeMatches)
+                                        {
+                                            Player opponent = GameManager.Instance.GetOpponentOf(ai);
+
+                                            var target = opponent.Battlefield
+                                                .OfType<EnchantmentCard>()
+                                                .OrderByDescending(c =>
+                                                {
+                                                    var data = CardDatabase.GetCardData(c.cardName);
+                                                    return data != null ? data.manaCost : 0;
+                                                })
+                                                .FirstOrDefault();
+
+                                            if (target != null)
+                                            {
+                                                sorcery.chosenTarget = target;
+                                                sorcery.chosenPlayerTarget = null;
+                                                Debug.Log($"AI targets {target.cardName} with {sorcery.cardName} (highest cost enchantment).");
                                             }
                                         }
                                         else if (sorcery.requiredTargetType == SorceryCard.TargetType.Land &&


### PR DESCRIPTION
## Summary
- add new TargetType and PermanentTypeToDestroy enums for Enchantment
- support enchantment targeting logic in GameManager, CardVisual, SorceryCard, and TurnSystem
- add Veilbreaker Druid creature card that destroys an enchantment on entering the battlefield

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68691d1ec8e483279ce489d507483d13