### PR TITLE
Add AI play delay

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -351,7 +351,7 @@ public class TurnSystem : MonoBehaviour
                                     ai.hasPlayedLandThisTurn = true;
 
                                     waitingForAIAction = true;
-                                    StartCoroutine(WaitForAIAction(0.5f));
+                                    StartCoroutine(WaitForAIAction(1f));
                                     return;
                                 }
                             }
@@ -452,7 +452,7 @@ public class TurnSystem : MonoBehaviour
                                         playedCard = true;
 
                                         waitingForAIAction = true;
-                                        StartCoroutine(WaitForAIAction(0.5f));
+                                        StartCoroutine(WaitForAIAction(1f));
                                         return;
                                     }
                                 }


### PR DESCRIPTION
## Summary
- slow down AI so actions are clearer
- pause briefly after AI plays lands or creatures

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686f7c84f3f0832781fe6079bc34be29