### PR TITLE
Fix missing subtypes support

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -21,6 +21,9 @@ public class Card
     public List<string> color = new List<string>();
     public string PrimaryColor => color.Count > 0 ? color[0] : "None";
 
+    // e.g. "Human", "Wizard"
+    public List<string> subtypes = new List<string>();
+
     public string rulesText;
     public string flavorText;
 

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -124,6 +124,7 @@ public static class CardFactory
         newCard.manaCost = data.manaCost;
         newCard.hasXCost = data.hasXCost;
         newCard.color = data.color != null ? new List<string>(data.color) : new List<string>();
+        newCard.subtypes = data.subtypes != null ? new List<string>(data.subtypes) : new List<string>();
         newCard.artwork = data.artwork;
         newCard.entersTapped = data.entersTapped;
         newCard.abilities = new List<CardAbility>(data.abilities);


### PR DESCRIPTION
## Summary
- add a `subtypes` field to `Card`
- initialize card `subtypes` in `CardFactory`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687116eec0488327bb5f3309d8dd4353