### PR TITLE
Fix blocking icon persistence after creature returns

### DIFF
--- a/Assets/Scripts/CreatureCard.cs
+++ b/Assets/Scripts/CreatureCard.cs
@@ -79,6 +79,10 @@ public class CreatureCard : Card
     public override void OnLeavePlay(Player owner)
     {
         base.OnLeavePlay(owner);
+        // Clear combat state when this creature leaves the battlefield so
+        // it won't retain old attack/block icons if it returns later.
+        blockingThisAttacker = null;
+        blockedByThisBlocker.Clear();
         plusOneCounters = 0;
         minusOneCounters = 0;
         ResetTemporaryBuff();


### PR DESCRIPTION
## Summary
- clear blocking references when creatures leave play

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68711a9de39c8327b05f868c5fe49c01