### PR TITLE
Add AI delay for artifact and enchantment plays

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -669,7 +669,10 @@ public class TurnSystem : MonoBehaviour
 
                                         Debug.Log($"AI played artifact: {card.cardName}");
                                         playedCard = true;
-                                        break;
+
+                                        waitingForAIAction = true;
+                                        StartCoroutine(WaitForAIAction(1f));
+                                        return;
                                     }
                                 }
                                 else if (card is EnchantmentCard enchantment)
@@ -710,7 +713,10 @@ public class TurnSystem : MonoBehaviour
 
                                         Debug.Log($"AI played enchantment: {card.cardName}");
                                         playedCard = true;
-                                        break;
+
+                                        waitingForAIAction = true;
+                                        StartCoroutine(WaitForAIAction(1f));
+                                        return;
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- add a pause when the AI plays artifacts or enchantments

## Testing
- `mcs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871214017d083279bd95b68e0aa1046