### PR TITLE
Add Sacred Horn aura

### DIFF
--- a/Assets/Scripts/AuraCard.cs
+++ b/Assets/Scripts/AuraCard.cs
@@ -13,6 +13,9 @@ public class AuraCard : EnchantmentCard
         if (attachedTo is CreatureCard creature)
         {
             creature.AddAuraBuff(buffPower, buffToughness);
+            if (keywordBuff != KeywordAbility.None)
+                creature.AddAuraKeyword(keywordBuff);
+            GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
         }
     }
 
@@ -21,6 +24,9 @@ public class AuraCard : EnchantmentCard
         if (attachedTo is CreatureCard creature)
         {
             creature.RemoveAuraBuff(buffPower, buffToughness);
+            if (keywordBuff != KeywordAbility.None)
+                creature.RemoveAuraKeyword(keywordBuff);
+            GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
         }
         attachedTo = null;
         base.OnLeavePlay(owner);

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -35,6 +35,7 @@ public class Card
     public int damageToCreature;
     public int buffPower;
     public int buffToughness;
+    public KeywordAbility keywordBuff = KeywordAbility.None;
 
     public string tokenToCreate;
 

--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -74,6 +74,7 @@ public class CardData
     public int damageToTarget = 0;
     public int powerBuff = 0;
     public int toughnessBuff = 0;
+    public KeywordAbility keywordBuff = KeywordAbility.None;
     public KeywordAbility keywordToGrant = KeywordAbility.None;
     public bool addXPlusOneCounters = false;
     public bool addXMinusOneCounters = false;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -3114,6 +3114,21 @@ public static class CardDatabase
                         rulesText = "Enchanted creature gets +0/+4",
                     });
 
+                Add(new CardData // Sacred Horn
+                    {
+                        cardName = "Sacred Horn",
+                        rarity = "Common",
+                        manaCost = 2,
+                        color = new List<string> { "White" },
+                        cardType = CardType.Enchantment,
+                        subtypes = new List<string> { "Aura" },
+                        powerBuff = 1,
+                        toughnessBuff = 1,
+                        keywordBuff = KeywordAbility.Lifelink,
+                        artwork = Resources.Load<Sprite>("Art/sacred_horn"),
+                        rulesText = "Enchanted creature gets +1/+1 and has lifelink",
+                    });
+
                 Add(new CardData // Cut off Hands
                     {
                         cardName = "Cut off Hands",

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -114,6 +114,7 @@ public static class CardFactory
                 enchantment.damageToCreature = data.damageToCreature;
                 enchantment.buffPower = data.powerBuff;
                 enchantment.buffToughness = data.toughnessBuff;
+                enchantment.keywordBuff = data.keywordBuff;
                 newCard = enchantment;
                 break;
 
@@ -135,6 +136,7 @@ public static class CardFactory
         newCard.rulesText = data.rulesText;
         newCard.flavorText = data.flavorText;
         newCard.isToken = data.isToken;
+        newCard.keywordBuff = data.keywordBuff;
 
         Debug.Log($"{newCard.cardName} created with {newCard.abilities.Count} abilities.");
 

--- a/Assets/Scripts/CreatureCard.cs
+++ b/Assets/Scripts/CreatureCard.cs
@@ -14,6 +14,7 @@ public class CreatureCard : Card
     public int tempToughnessBonus = 0;
     public int auraPowerBonus = 0;
     public int auraToughnessBonus = 0;
+    public List<KeywordAbility> auraKeywordAbilities = new List<KeywordAbility>();
 
     public void RecalculateStats()
     {
@@ -57,11 +58,27 @@ public class CreatureCard : Card
         RecalculateStats();
     }
 
+    public void AddAuraKeyword(KeywordAbility ability)
+    {
+        if (!keywordAbilities.Contains(ability))
+            keywordAbilities.Add(ability);
+        if (!auraKeywordAbilities.Contains(ability))
+            auraKeywordAbilities.Add(ability);
+    }
+
     public void RemoveAuraBuff(int powerAmount, int toughnessAmount)
     {
         auraPowerBonus -= powerAmount;
         auraToughnessBonus -= toughnessAmount;
         RecalculateStats();
+    }
+
+    public void RemoveAuraKeyword(KeywordAbility ability)
+    {
+        if (auraKeywordAbilities.Contains(ability))
+            auraKeywordAbilities.Remove(ability);
+        if (keywordAbilities.Contains(ability))
+            keywordAbilities.Remove(ability);
     }
     public int damageTaken = 0;
     public int tapLifeLossAmount;


### PR DESCRIPTION
## Summary
- support keyword buffs on auras
- add Sacred Horn aura card that grants +1/+1 and lifelink

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687234713af8832786758907487c8f5f