### PR TITLE
Fix sorcery resolution when damaging players

### DIFF
--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -485,5 +485,6 @@ public class SorceryCard : Card
             }
 
             GameManager.Instance.UpdateUI();
+            ResolveEffect(caster);
         }
 }


### PR DESCRIPTION
## Summary
- handle follow-up effects when a sorcery damages a player

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68726f2ef9a88327acb68d0344e513a3