### PR TITLE
Use darker emerald green for boosted stats

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -228,7 +228,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
     private string ColorStat(int current, int baseValue)
         {
             if (current > baseValue)
-                return $"<color=#00ff00>{current}</color>";
+                // Use a darker shade of green (emerald) when stats are boosted
+                return $"<color=#50C878>{current}</color>";
             if (current < baseValue)
                 return $"<color=#ff0000>{current}</color>";
             return current.ToString();


### PR DESCRIPTION
## Summary
- tweak the stat color for buffed creatures to use an emerald green instead of bright neon green

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6872a2ed28148327962339dd5ffa1b69