### PR TITLE
Add Devouring Fury aura

### DIFF
--- a/Assets/Scripts/AuraCard.cs
+++ b/Assets/Scripts/AuraCard.cs
@@ -6,6 +6,7 @@ public class AuraCard : EnchantmentCard
 {
     public SorceryCard.TargetType requiredTargetType = SorceryCard.TargetType.Creature;
     public Card attachedTo;
+    public bool targetMustBeControlledCreature = false;
 
     public override void OnEnterPlay(Player owner)
     {

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -116,13 +116,15 @@ public class Card
         {
             List<string> lines = new List<string>();
 
-            if (this is AuraCard aura)
-            {
-                if (aura.requiredTargetType == SorceryCard.TargetType.Creature)
-                    lines.Add("Enchant creature");
-                else if (aura.requiredTargetType == SorceryCard.TargetType.TappedCreature)
-                    lines.Add("Enchant tapped creature");
-            }
+        if (this is AuraCard aura)
+        {
+            string enchantText = aura.requiredTargetType == SorceryCard.TargetType.TappedCreature
+                ? "Enchant tapped creature"
+                : "Enchant creature";
+            if (aura.targetMustBeControlledCreature)
+                enchantText += " you control";
+            lines.Add(enchantText);
+        }
 
             // Keyword abilities — only for creatures
             if (this is CreatureCard creature)

--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -75,6 +75,7 @@ public class CardData
     public int powerBuff = 0;
     public int toughnessBuff = 0;
     public KeywordAbility keywordBuff = KeywordAbility.None;
+    public bool targetMustBeControlledCreature = false;
     public KeywordAbility keywordToGrant = KeywordAbility.None;
     public bool addXPlusOneCounters = false;
     public bool addXMinusOneCounters = false;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -3221,6 +3221,21 @@ public static class CardDatabase
                         rulesText = "Enchanted creature gets -2/-2",
                     });
 
+                Add(new CardData // Devouring Fury
+                    {
+                        cardName = "Devouring Fury",
+                        rarity = "Common",
+                        manaCost = 1,
+                        color = new List<string> { "Red" },
+                        cardType = CardType.Enchantment,
+                        subtypes = new List<string> { "Aura" },
+                        powerBuff = 4,
+                        toughnessBuff = -2,
+                        targetMustBeControlledCreature = true,
+                        artwork = Resources.Load<Sprite>("Art/devouring_fury"),
+                        rulesText = "Enchanted creature gets +4/-2.",
+                    });
+
                 Add(new CardData // Woodskin
                     {
                         cardName = "Woodskin",

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -120,6 +120,8 @@ public static class CardFactory
                         data.requiredTargetType == SorceryCard.TargetType.None
                             ? SorceryCard.TargetType.Creature
                             : data.requiredTargetType;
+                if (enchantment is AuraCard aura2)
+                    aura2.targetMustBeControlledCreature = data.targetMustBeControlledCreature;
                 newCard = enchantment;
                 break;
 

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -706,8 +706,10 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 if (linkedCard is CreatureCard linkedCreature)
                 {
                     var aura = GameManager.Instance.targetingAura;
-                    bool valid = aura.requiredTargetType == SorceryCard.TargetType.Creature ||
-                                 (aura.requiredTargetType == SorceryCard.TargetType.TappedCreature && linkedCreature.isTapped);
+                    bool valid = (aura.requiredTargetType == SorceryCard.TargetType.Creature ||
+                                  (aura.requiredTargetType == SorceryCard.TargetType.TappedCreature && linkedCreature.isTapped)) &&
+                                 (!aura.targetMustBeControlledCreature ||
+                                  GameManager.Instance.GetOwnerOfCard(linkedCreature) == GameManager.Instance.targetingPlayer);
                     if (valid)
                     {
                         GameManager.Instance.CompleteTargetSelection(this);

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1773,9 +1773,11 @@ public class GameManager : MonoBehaviour
             bool correctType =
                 (targetingAura.requiredTargetType == SorceryCard.TargetType.Creature && targetCard is CreatureCard) ||
                 (targetingAura.requiredTargetType == SorceryCard.TargetType.TappedCreature && targetCard is CreatureCard tc && tc.isTapped);
-            bool isOnBattlefield = GetOwnerOfCard(targetCard)?.Battlefield.Contains(targetCard) == true;
+            Player targetOwner = GetOwnerOfCard(targetCard);
+            bool isOnBattlefield = targetOwner?.Battlefield.Contains(targetCard) == true;
+            bool correctController = !targetingAura.targetMustBeControlledCreature || targetOwner == targetingPlayer;
 
-            if (!correctType || !isOnBattlefield)
+            if (!correctType || !isOnBattlefield || !correctController)
             {
                 Debug.Log("Invalid target for aura.");
                 CancelTargeting();


### PR DESCRIPTION
## Summary
- introduce `targetMustBeControlledCreature` flag for auras
- show "you control" in aura text and prevent targeting opponent creatures
- create new common red aura card **Devouring Fury** that grants +4/-2

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_68742b8616608327a4add9d1173df47c