### PR TITLE
Fix aura immediate death on negative toughness

### DIFF
--- a/Assets/Scripts/AuraCard.cs
+++ b/Assets/Scripts/AuraCard.cs
@@ -17,6 +17,11 @@ public class AuraCard : EnchantmentCard
             if (keywordBuff != KeywordAbility.None)
                 creature.AddAuraKeyword(keywordBuff);
             GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
+
+            // If toughness falls to zero or less, creature (and this aura)
+            // should immediately die.
+            GameManager.Instance.CheckDeaths(GameManager.Instance.humanPlayer);
+            GameManager.Instance.CheckDeaths(GameManager.Instance.aiPlayer);
         }
     }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1809,6 +1809,17 @@ public class GameManager : MonoBehaviour
             targetingAura.OnEnterPlay(targetingPlayer);
             NotifyEnchantmentEntered(targetingAura, targetingPlayer);
 
+            // The enchanted creature might have died from the aura's effect.
+            if (!targetingPlayer.Battlefield.Contains(targetingAura))
+            {
+                targetingAura = null;
+                targetingPlayer = null;
+                targetingVisual = null;
+                isTargetingMode = false;
+                UpdateUI();
+                return;
+            }
+
             if (targetingAura.entersTapped || IsAllPermanentsEnterTappedActive())
             {
                 targetingAura.isTapped = true;

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -711,9 +711,17 @@ public class TurnSystem : MonoBehaviour
                                         ai.Hand.Remove(card);
                                         auraCard.attachedTo = target;
                                         auraCard.owner = ai;
-                                        ai.Battlefield.Add(auraCard);
-                                        auraCard.OnEnterPlay(ai);
-                                        GameManager.Instance.NotifyEnchantmentEntered(auraCard, ai);
+                                       ai.Battlefield.Add(auraCard);
+                                       auraCard.OnEnterPlay(ai);
+                                       GameManager.Instance.NotifyEnchantmentEntered(auraCard, ai);
+
+                                        // Aura or enchanted creature might die upon entry
+                                        if (!ai.Battlefield.Contains(auraCard))
+                                        {
+                                            waitingForAIAction = true;
+                                            StartCoroutine(WaitForAIAction(1f));
+                                            return;
+                                        }
 
                                         if (auraCard.entersTapped || GameManager.Instance.IsAllPermanentsEnterTappedActive())
                                         {


### PR DESCRIPTION
## Summary
- check deaths when aura enters play
- stop aura cast sequence if aura dies upon entry
- ensure AI aura casting handles instant deaths

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742f5afcb883278f990ff039e78126