### PR TITLE
Fix aura highlight removal when entering graveyard

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -614,6 +614,8 @@ public class GameManager : MonoBehaviour
             card.isTapped = false;
 
             CardVisual visual = FindCardVisual(card); // <-- Moved up
+            if (visual != null)
+                visual.EnableTargetingHighlight(false); // ensure highlight removed
             if (visual != null && visual.tapIcon != null)
                 visual.tapIcon.SetActive(false);
 
@@ -2544,6 +2546,9 @@ public class GameManager : MonoBehaviour
 
         private IEnumerator ShowDeathVFXAndDelayLayout(Card card, Player owner, CardVisual visual)
             {
+                if (visual != null)
+                    visual.EnableTargetingHighlight(false); // ensure highlight removed
+
                 pendingGraveyardAnimations++;
 
                 // 1. Create a placeholder object in the same layout slot
@@ -2585,6 +2590,9 @@ public class GameManager : MonoBehaviour
 
         private IEnumerator ShowHandDiscardVFX(Card card, Player owner, CardVisual visual)
             {
+                if (visual != null)
+                    visual.EnableTargetingHighlight(false); // ensure highlight removed
+
                 // 1. Create placeholder
                 Transform parent = visual.transform.parent;
                 GameObject placeholder = Instantiate(deathPlaceholderPrefab, parent);


### PR DESCRIPTION
## Summary
- disable targeting highlight for cards when they move to graveyard
- ensure highlight is also cleared during death/discard visual effects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68743d5ed07c8327a56bd8df7b47c94e