### PR TITLE
Fix DeckDatabase typos

### DIFF
--- a/Assets/Scripts/DeckDatabase.cs
+++ b/Assets/Scripts/DeckDatabase.cs
@@ -108,8 +108,8 @@ public static class DeckDatabase
             ai.Deck.Add(CardFactory.Create("Beasthunter"));
             ai.Deck.Add(CardFactory.Create("Candlelight"));
             ai.Deck.Add(CardFactory.Create("Candlelight"));
-            ai.Deck.Add(CardFactory.Create("Bonefire"));
-            ai.Deck.Add(CardFactory.Create("Bonefire"));
+            ai.Deck.Add(CardFactory.Create("Bonfire"));
+            ai.Deck.Add(CardFactory.Create("Bonfire"));
         }
 
     public static void BuildWhiteAdvancedDeck(Player ai)
@@ -134,7 +134,7 @@ public static class DeckDatabase
             ai.Deck.Add(CardFactory.Create("Waterbearer"));
             ai.Deck.Add(CardFactory.Create("Waterbearer"));
             ai.Deck.Add(CardFactory.Create("Waterbearer"));
-            ai.Deck.Add(CardFactory.Create("Faith Incarnated"));
+            ai.Deck.Add(CardFactory.Create("Faith Incarnate"));
             ai.Deck.Add(CardFactory.Create("Iconoclast Monk"));
             ai.Deck.Add(CardFactory.Create("Iconoclast Monk"));
             ai.Deck.Add(CardFactory.Create("Iconoclast Monk"));
@@ -226,7 +226,7 @@ public static class DeckDatabase
             ai.Deck.Add(CardFactory.Create("Lucky Fisherman"));
             ai.Deck.Add(CardFactory.Create("Lucky Fisherman"));
             ai.Deck.Add(CardFactory.Create("Lucky Fisherman"));
-            ai.Deck.Add(CardFactory.Create("Windsom Incarnate"));
+            ai.Deck.Add(CardFactory.Create("Wisdom Incarnate"));
             ai.Deck.Add(CardFactory.Create("Tide Spirit"));
             ai.Deck.Add(CardFactory.Create("Tide Spirit"));
             ai.Deck.Add(CardFactory.Create("Tide Spirit"));
@@ -379,8 +379,8 @@ public static class DeckDatabase
             ai.Deck.Add(CardFactory.Create("To Dig a Hole"));
             ai.Deck.Add(CardFactory.Create("Crystallium"));
             ai.Deck.Add(CardFactory.Create("Crystallium"));
-            ai.Deck.Add(CardFactory.Create("Wild OStrich"));
-            ai.Deck.Add(CardFactory.Create("Wild OStrich"));
+            ai.Deck.Add(CardFactory.Create("Wild Ostrich"));
+            ai.Deck.Add(CardFactory.Create("Wild Ostrich"));
         }
 
     public static void BuildRedAdvancedDeck(Player ai)
@@ -416,13 +416,13 @@ public static class DeckDatabase
             ai.Deck.Add(CardFactory.Create("Thundermare"));
             ai.Deck.Add(CardFactory.Create("Thundermare"));
             ai.Deck.Add(CardFactory.Create("Thundermare"));
-            ai.Deck.Add(CardFactory.Create("Fire Spirlas"));
+            ai.Deck.Add(CardFactory.Create("Fire Spirals"));
             ai.Deck.Add(CardFactory.Create("Fireborn Dragon"));
             ai.Deck.Add(CardFactory.Create("Fireborn Dragon"));
             ai.Deck.Add(CardFactory.Create("Dragon Summoner"));
             ai.Deck.Add(CardFactory.Create("Dragon Summoner"));
             ai.Deck.Add(CardFactory.Create("Potion of Knowledge"));
-            ai.Deck.Add(CardFactory.Create("Fire Spirlas"));
+            ai.Deck.Add(CardFactory.Create("Fire Spirals"));
             ai.Deck.Add(CardFactory.Create("Thunderstrike"));
             ai.Deck.Add(CardFactory.Create("War Incarnate"));
             ai.Deck.Add(CardFactory.Create("Melt"));
@@ -605,6 +605,6 @@ public static class DeckDatabase
             ai.Deck.Add(CardFactory.Create("Potion of Lava"));
             ai.Deck.Add(CardFactory.Create("Pressure Sphere"));
             ai.Deck.Add(CardFactory.Create("Trinkets Collector"));
-            ai.Deck.Add(CardFactory.Create("Blast Oìof Knowledge"));
+            ai.Deck.Add(CardFactory.Create("Blast of Knowledge"));
         }
 }


### PR DESCRIPTION
## Summary
- fix typos in DeckDatabase card names
- ensure all card names match CardDatabase entries

## Testing
- `python3 - <<'PY'
import re
names=set()
with open('Assets/Scripts/CardDatabase.cs') as f:
    for line in f:
        m=re.search(r'cardName\s*=\s*"([^"]+)"', line)
        if m:
            names.add(m.group(1))
missing=[]
with open('Assets/Scripts/DeckDatabase.cs') as f:
    for i,line in enumerate(f,1):
        m=re.search(r'CardFactory.Create\("([^"]+)"\)', line)
        if m:
            card=m.group(1)
            if card not in names:
                missing.append((i,card))
print('missing count',len(missing))
for line,card in missing[:20]:
    print(line,card)
PY

------
https://chatgpt.com/codex/tasks/task_e_6875264ee00c8327a3d9a9f4fc2a383b