### PR TITLE
Prevent AI from attacking with zero power creatures

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1279,9 +1279,13 @@ public class TurnSystem : MonoBehaviour
             }
 
         private bool ShouldAIAttackCreature(CreatureCard creature, Player ai, Player human, bool goForLethal, bool lowLifeNeedsDefense)
-            {
-                if (goForLethal)
-                    return true;
+        {
+            // Avoid attacking with creatures that cannot deal damage
+            if (creature.power <= 0)
+                return false;
+
+            if (goForLethal)
+                return true;
 
                 if (lowLifeNeedsDefense && !creature.keywordAbilities.Contains(KeywordAbility.Vigilance))
                     return false;


### PR DESCRIPTION
## Summary
- stop AI from declaring attackers if their power is 0 or less

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878f30b36d48327afe11c4abe1f5fb9