### PR TITLE
Restore aura casting glow

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -2432,6 +2432,11 @@ public class GameManager : MonoBehaviour
         targetingPlayer = caster;
         targetingVisual = visual;
         isTargetingMode = true;
+
+        // Highlight the aura being cast so the player has feedback similar to
+        // sorceries while choosing a target
+        if (visual != null)
+            visual.EnableTargetingHighlight(true);
     }
 
     public void BeginEquipmentTargetSelection(EquipmentCard equipment, Player player, CardVisual visual)


### PR DESCRIPTION
## Summary
- highlight aura card when selecting targets to cast

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cf6ffac4c8327b1194b79fab976d7