### PR TITLE
Fix duplicate life gain display for Potion of Health

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1210,7 +1210,6 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         GameManager.Instance.UpdateUI();
                         UpdateVisual();
 
-                        GameManager.Instance.ShowFloatingHeal(artifact.lifeToGain, GameManager.Instance.playerLifeContainer);
                         Debug.Log($"{linkedCard.cardName} activated: Gain {artifact.lifeToGain} life.");
                     }
                     else


### PR DESCRIPTION
## Summary
- remove extra floating heal call when activating SacrificeForLife

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fba4e5b508327abf4f175e5b9ef0e