### PR TITLE
Add deck editor card click handling

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -724,6 +724,12 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     dg.RerollCard(transform.GetSiblingIndex());
                 return;
             }
+            if (SceneManager.GetActiveScene().name == "DeckEditorScene")
+            {
+                var mgr = FindObjectOfType<DeckEditorManager>();
+                if (mgr != null) mgr.OnCardClicked(this);
+                return;
+            }
             if (isInStack)
                 return;
             // Optional ETB targeting (e.g. Monk: "You may destroy target artifact")


### PR DESCRIPTION
## Summary
- enable card removal by clicking card visuals in the deck editor

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fcfb92e888327aa4c0c97789a0cd6