### PR TITLE
Award random card on win

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -191,6 +191,7 @@ public class GameManager : MonoBehaviour
             if (player == aiPlayer)
             {
                 Debug.Log("AI tried to draw from an empty deck — player wins by mill.");
+                PlayerCollection.AddRandomCard();
                 gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowWinScreen();
             }
@@ -3534,6 +3535,7 @@ public class GameManager : MonoBehaviour
             if (aiPlayer.Life <= 0)
             {
                 Debug.Log("AI defeated — player wins!");
+                PlayerCollection.AddRandomCard();
                 gameOver = true;
                 FindObjectOfType<WinScreenUI>().ShowWinScreen();
             }

--- a/Assets/Scripts/PlayerCollection.cs
+++ b/Assets/Scripts/PlayerCollection.cs
@@ -1,6 +1,20 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 public static class PlayerCollection
 {
     public static List<CardData> OwnedCards = new List<CardData>();
+
+    /// <summary>
+    /// Adds a random card from the CardDatabase to the player's collection.
+    /// </summary>
+    public static void AddRandomCard()
+    {
+        var allCards = new List<CardData>(CardDatabase.GetAllCards());
+        if (allCards.Count == 0)
+            return;
+
+        int index = Random.Range(0, allCards.Count);
+        OwnedCards.Add(allCards[index]);
+    }
 }


### PR DESCRIPTION
## Summary
- add utility in `PlayerCollection` to grant a random card
- give a random card whenever the AI loses by deck out or by reaching 0 life

## Testing
- `echo "No tests present"`

------
https://chatgpt.com/codex/tasks/task_e_68800583fd6c8327a0fc37f9db35508a