### PR TITLE
Fix deck editor not showing owned cards

### DIFF
--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -18,6 +18,26 @@ public class DeckEditorManager : MonoBehaviour
         if (DeckHolder.SelectedDeck != null)
             deck = new List<CardData>(DeckHolder.SelectedDeck);
         ShowDeck();
+
+        LoadRemovedList();
+    }
+
+    private void LoadRemovedList()
+    {
+        foreach (Transform child in removedListContainer)
+            Destroy(child.gameObject);
+
+        collection = new List<CardData>(PlayerCollection.OwnedCards);
+
+        foreach (var data in collection)
+        {
+            GameObject entry = Instantiate(textPrefab, removedListContainer);
+            TMP_Text text = entry.GetComponentInChildren<TMP_Text>();
+            if (text != null)
+                text.text = data.cardName;
+        }
+
+        UpdateRemovedButtons();
     }
 
     private void ShowDeck()


### PR DESCRIPTION
## Summary
- load owned cards when opening the deck editor
- add helper method to populate the removed list from `PlayerCollection`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688009c7f7b88327a2cff5bdee892e24