### PR TITLE
Fix deck editor filter interactions

### DIFF
--- a/Assets/Scripts/DeckEditorCardButton.cs
+++ b/Assets/Scripts/DeckEditorCardButton.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class DeckEditorCardButton : MonoBehaviour
+{
+    public CardData Data { get; private set; }
+    private DeckEditorManager manager;
+
+    public void Initialize(CardData data, DeckEditorManager mgr)
+    {
+        Data = data;
+        manager = mgr;
+        var btn = GetComponent<Button>();
+        if (btn != null)
+        {
+            btn.onClick.RemoveAllListeners();
+            btn.onClick.AddListener(OnClick);
+        }
+    }
+
+    private void OnClick()
+    {
+        manager?.OnCardClicked(Data, gameObject);
+    }
+}

--- a/Assets/Scripts/DeckEditorCollectionButton.cs
+++ b/Assets/Scripts/DeckEditorCollectionButton.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class DeckEditorCollectionButton : MonoBehaviour
+{
+    public CardData Data { get; private set; }
+    private DeckEditorManager manager;
+
+    public void Initialize(CardData data, DeckEditorManager mgr)
+    {
+        Data = data;
+        manager = mgr;
+        var btn = GetComponent<Button>();
+        if (btn != null)
+        {
+            btn.onClick.RemoveAllListeners();
+            btn.onClick.AddListener(OnClick);
+        }
+    }
+
+    private void OnClick()
+    {
+        manager?.OnCollectionEntryClicked(Data, gameObject);
+    }
+}

--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -140,35 +140,29 @@ public class DeckEditorManager : MonoBehaviour
         CardData sourceData = CardDatabase.GetCardData(card.cardName);
         visual.Setup(card, null, sourceData);
 
-        Button btn = go.GetComponent<Button>();
-        btn.onClick.RemoveAllListeners();
-        btn.onClick.AddListener(() => OnCardClicked(visual));
+        var handler = go.AddComponent<DeckEditorCardButton>();
+        handler.Initialize(data, this);
     }
 
-    public void OnCardClicked(CardVisual visual)
+    public void OnCardClicked(CardData data, GameObject visual)
     {
-        int index = visual.transform.GetSiblingIndex();
-        if (index < 0 || index >= deck.Count)
+        if (!deck.Remove(data))
             return;
 
-        CardData data = deck[index];
-        deck.RemoveAt(index);
         collection.Add(data);
         PlayerCollection.OwnedCards.Add(data);
-        Destroy(visual.gameObject);
+        Destroy(visual);
 
         RefreshCollectionDisplay();
     }
 
-    public void OnTextClicked(int index)
+    public void OnCollectionEntryClicked(CardData data, GameObject entry)
     {
-        if (index < 0 || index >= collection.Count)
+        if (!collection.Remove(data))
             return;
 
-        CardData data = collection[index];
-        collection.RemoveAt(index);
         PlayerCollection.OwnedCards.Remove(data);
-        Destroy(removedListContainer.GetChild(index).gameObject);
+        Destroy(entry);
 
         GameObject prefab = cardPrefab;
         if (prefab == null)
@@ -187,12 +181,9 @@ public class DeckEditorManager : MonoBehaviour
     {
         for (int i = 0; i < removedListContainer.childCount; i++)
         {
-            int idx = i;
-            Button btn = removedListContainer.GetChild(i).GetComponent<Button>();
-            if (btn == null)
-                continue;
-            btn.onClick.RemoveAllListeners();
-            btn.onClick.AddListener(() => OnTextClicked(idx));
+            var entry = removedListContainer.GetChild(i);
+            var handler = entry.gameObject.AddComponent<DeckEditorCollectionButton>();
+            handler.Initialize(collection[i], this);
         }
     }
 


### PR DESCRIPTION
## Summary
- refactor deck editor logic so card and collection buttons store card data
- use new helper components instead of relying on sibling indexes
- update manager to work with the new components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880dbbfbe00832781879f26565495e4