### PR TITLE
Fix DeckEditor click callback

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -727,7 +727,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             if (SceneManager.GetActiveScene().name == "DeckEditorScene")
             {
                 var mgr = FindObjectOfType<DeckEditorManager>();
-                if (mgr != null) mgr.OnCardClicked(this);
+                if (mgr != null)
+                {
+                    CardData data = CardDatabase.GetCardData(linkedCard.cardName);
+                    mgr.OnCardClicked(data, gameObject);
+                }
                 return;
             }
             if (isInStack)


### PR DESCRIPTION
## Summary
- fix `OnCardClicked` call in `CardVisual` to pass `CardData` and the visual game object

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880de6564c08327914199ccb6ccb5bc