### PR TITLE
Fix deck editor card re-add bug

### DIFF
--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -158,8 +158,11 @@ public class DeckEditorManager : MonoBehaviour
 
     public void OnCollectionEntryClicked(CardData data, GameObject entry)
     {
-        if (!collection.Remove(data))
-            return;
+        // Try to remove the card from the local collection list. In some edge
+        // cases the reference might not exist (for example after changing
+        // filters), but we still want to allow adding the card back to the deck
+        // even if the removal fails.
+        collection.Remove(data);
 
         PlayerCollection.OwnedCards.Remove(data);
         Destroy(entry);


### PR DESCRIPTION
## Summary
- ensure clicking a removed card always re-adds it to the deck

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880e09161808327b4c3290c7638126b