### PR TITLE
Add card type filters to DeckEditor

### DIFF
--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -16,6 +16,10 @@ public class DeckEditorManager : MonoBehaviour
     [SerializeField] private Button redFilterButton;
     [SerializeField] private Button greenFilterButton;
     [SerializeField] private Button colorlessFilterButton;
+    [Header("Type Filter Buttons")]
+    [SerializeField] private Button creatureFilterButton;
+    [SerializeField] private Button sorceryFilterButton;
+    [SerializeField] private Button enchantmentFilterButton;
     [Header("Filter Colors")]
     [SerializeField] private Color activeFilterColor = Color.yellow;
 
@@ -44,6 +48,9 @@ public class DeckEditorManager : MonoBehaviour
         SetupFilterButton(redFilterButton, "Red");
         SetupFilterButton(greenFilterButton, "Green");
         SetupFilterButton(colorlessFilterButton, "Colorless");
+        SetupFilterButton(creatureFilterButton, "Creature");
+        SetupFilterButton(sorceryFilterButton, "Sorcery");
+        SetupFilterButton(enchantmentFilterButton, "Enchantment");
 
         UpdateFilterButtonVisuals();
     }
@@ -84,6 +91,11 @@ public class DeckEditorManager : MonoBehaviour
             {
                 bool isColorless = colors.Count == 0 || colors.Contains("Artifact");
                 if (!isColorless)
+                    return false;
+            }
+            else if (filter == "Creature" || filter == "Sorcery" || filter == "Enchantment")
+            {
+                if (data.cardType.ToString() != filter)
                     return false;
             }
             else if (!colors.Contains(filter))


### PR DESCRIPTION
## Summary
- expose new filter buttons for card types in `DeckEditorManager`
- hook up the buttons for creature, sorcery and enchantment
- extend filtering logic so card type filters work alongside color filters

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688105a0e27883279cf21cf9d995c610