### PR TITLE
Add Tame aura card

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -3324,6 +3324,19 @@ public static class CardDatabase
                         rulesText = "Enchanted creature gets +1/+1 and has lifelink.",
                     });
 
+                Add(new CardData // Tame
+                    {
+                        cardName = "Tame",
+                        rarity = "Common",
+                        manaCost = 1,
+                        color = new List<string> { "White" },
+                        cardType = CardType.Enchantment,
+                        subtypes = new List<string> { "Aura" },
+                        keywordBuff = KeywordAbility.Defender,
+                        artwork = Resources.Load<Sprite>("Art/tame"),
+                        rulesText = "Enchanted creature has defender.",
+                    });
+
                 Add(new CardData // Cut off Hands
                     {
                         cardName = "Cut off Hands",


### PR DESCRIPTION
## Summary
- add the Tame aura card to the card database

## Testing
- `mcs -version` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688247be47f4832e83432debc9027ed8