### PR TITLE
Fix tapping opponent lands

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1534,8 +1534,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             // Land usage
                 if (isInBattlefield && linkedCard is LandCard land)
                 {
-                    GameManager.Instance.TapLandForMana(land, GameManager.Instance.humanPlayer);
-                    UpdateVisual();
+                    if (GameManager.Instance.GetOwnerOfCard(land) == GameManager.Instance.humanPlayer)
+                    {
+                        GameManager.Instance.TapLandForMana(land, GameManager.Instance.humanPlayer);
+                        UpdateVisual();
+                    }
                     return;
                 }
 

--- a/Assets/Scripts/LandCard.cs
+++ b/Assets/Scripts/LandCard.cs
@@ -14,7 +14,7 @@ public class LandCard : Card
 
     public void TapForMana(Player player)
     {
-        if (!isTapped)
+        if (!isTapped && GameManager.Instance.GetOwnerOfCard(this) == player)
         {
             GameManager.Instance.TapLandForMana(this, player);
         }


### PR DESCRIPTION
## Summary
- ensure land tapping only works for the human player's own lands
- safeguard `LandCard.TapForMana` with an owner check

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68835405b468832ea98370dc4164608a