### PR TITLE
Improve FPS camera checks and candle flicker

### DIFF
--- a/Assets/Scripts/CandleFlicker.cs
+++ b/Assets/Scripts/CandleFlicker.cs
@@ -5,15 +5,21 @@ public class CandleFlicker : MonoBehaviour
 {
     Light candleLight;
     float baseIntensity;
+    float noiseOffset;
+    public float noiseSpeed = 1f;
+    public float intensityRange = 0.2f;
 
     void Start()
     {
         candleLight = GetComponent<Light>();
         baseIntensity = candleLight.intensity;
+        noiseOffset = Random.Range(0f, 100f);
     }
 
     void Update()
     {
-        candleLight.intensity = baseIntensity + Random.Range(-0.2f, 0.2f);
+        float noise = Mathf.PerlinNoise(Time.time * noiseSpeed + noiseOffset, 0f);
+        float flicker = (noise - 0.5f) * 2f * intensityRange;
+        candleLight.intensity = Mathf.Max(0f, baseIntensity + flicker);
     }
 }

--- a/Assets/Scripts/FPSPlayer.cs
+++ b/Assets/Scripts/FPSPlayer.cs
@@ -18,6 +18,19 @@ public class FPSPlayer : MonoBehaviour
         Cursor.visible = false;
         rb = GetComponent<Rigidbody>();
         rb.freezeRotation = true; // prevent physics from rotating the player
+
+        if (cameraTransform == null)
+        {
+            Camera cam = GetComponentInChildren<Camera>();
+            if (cam != null)
+            {
+                cameraTransform = cam.transform;
+            }
+            else
+            {
+                Debug.LogWarning("FPSPlayer cameraTransform is not assigned and no child camera found.");
+            }
+        }
     }
 
     void Update()
@@ -28,14 +41,17 @@ public class FPSPlayer : MonoBehaviour
         movementInput = (transform.right * x + transform.forward * z).normalized * moveSpeed;
 
         // Mouse Look
-        float mouseX = Input.GetAxis("Mouse X") * mouseSensitivity;
-        float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity;
+        float mouseX = Input.GetAxis("Mouse X") * mouseSensitivity * Time.deltaTime;
+        float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity * Time.deltaTime;
 
         transform.Rotate(Vector3.up * mouseX);
 
         verticalLookRotation -= mouseY;
         verticalLookRotation = Mathf.Clamp(verticalLookRotation, -90f, 90f);
-        cameraTransform.localEulerAngles = Vector3.right * verticalLookRotation;
+        if (cameraTransform != null)
+        {
+            cameraTransform.localEulerAngles = Vector3.right * verticalLookRotation;
+        }
     }
 
     void FixedUpdate()


### PR DESCRIPTION
## Summary
- ensure the camera reference for `FPSPlayer` is set and warn if none is found
- scale mouse look by `Time.deltaTime`
- guard against null camera in Update
- smooth `CandleFlicker` intensity with Perlin noise and clamp to positive values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883af7fb720832e866ab916d10a794e