### PR TITLE
Add Rolling Insight sorcery

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -50,6 +50,8 @@ public class CardData
     public ArtifactEffect artifactEffect = ArtifactEffect.None;
     public int plagueAmount;
     public int cardsToDraw;
+    public int cardsToDrawMin = 0;
+    public int cardsToDrawMax = 0;
     public int manaToPayToActivate;
 
     //For sorceries

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2390,6 +2390,16 @@ public static class CardDatabase
                     swapGraveyardAndLibrary = true,
                     artwork = Resources.Load<Sprite>("Art/astral_plane"),
                     });
+                Add(new CardData { //Rolling Insight
+                    cardName = "Rolling Insight",
+                    rarity = "Uncommon",
+                    cardType = CardType.Sorcery,
+                    manaCost = 6,
+                    color = new List<string> { "Blue" },
+                    cardsToDrawMin = 1,
+                    cardsToDrawMax = 6,
+                    artwork = Resources.Load<Sprite>("Art/rolling_insight"),
+                    });
             //BLACK
                 Add(new CardData { //Blasphemy
                     cardName = "Blasphemy",

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -62,6 +62,8 @@ public static class CardFactory
                 sorcery.tokenToCreate = data.tokenToCreate;
                 sorcery.numberOfTokensMin = data.numberOfTokensMin;
                 sorcery.numberOfTokensMax = data.numberOfTokensMax;
+                sorcery.cardsToDrawMin = data.cardsToDrawMin;
+                sorcery.cardsToDrawMax = data.cardsToDrawMax;
                 sorcery.requiresTarget = data.requiresTarget;
                 sorcery.requiredTargetType = data.requiredTargetType;
                 sorcery.damageToTarget = data.damageToTarget;

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1837,7 +1837,16 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 rules += $"Opponent loses {sorcery.lifeToLoseForOpponent} life.\n";
             if (sorcery.lifeLossForBothPlayers > 0)
                 rules += $"Each player loses {sorcery.lifeLossForBothPlayers} life.\n";
-            if (sorcery.cardsToDraw > 0)
+            if (sorcery.cardsToDrawMax > 0)
+            {
+                int min = sorcery.cardsToDrawMin;
+                int max = sorcery.cardsToDrawMax;
+                if (min == max)
+                    rules += $"Draw {min} card(s).\n";
+                else
+                    rules += $"Draw {min}-{max} cards.\n";
+            }
+            else if (sorcery.cardsToDraw > 0)
                 rules += $"Draw {sorcery.cardsToDraw} card(s).\n";
             if (!string.IsNullOrEmpty(sorcery.tokenToCreate) && sorcery.numberOfTokensMax > 0)
             {

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -22,6 +22,8 @@ public class SorceryCard : Card
     public int maxManaCostForReturn = 0;
     public int numberOfTokensMin = 0;
     public int numberOfTokensMax = 0;
+    public int cardsToDrawMin = 0;
+    public int cardsToDrawMax = 0;
     public Card chosenTarget = null;
     public int damageToTarget = 0;
     public bool destroyTargetIfTypeMatches = false;
@@ -142,12 +144,21 @@ public class SorceryCard : Card
                 GameManager.Instance.CheckForGameEnd();
                 didSomething = true;
             }
-            if (cardsToDraw > 0)
-                {
-                    GameManager.Instance.DrawCards(caster, cardsToDraw);
-                    Debug.Log($"{caster} draws {cardsToDraw} card(s).");
-                    didSomething = true;
-                }
+            if (cardsToDrawMax > 0)
+            {
+                int amount = (cardsToDrawMin == cardsToDrawMax)
+                    ? cardsToDrawMin
+                    : Random.Range(cardsToDrawMin, cardsToDrawMax + 1);
+                GameManager.Instance.DrawCards(caster, amount);
+                Debug.Log($"{caster} draws {amount} card(s).");
+                didSomething = true;
+            }
+            else if (cardsToDraw > 0)
+            {
+                GameManager.Instance.DrawCards(caster, cardsToDraw);
+                Debug.Log($"{caster} draws {cardsToDraw} card(s).");
+                didSomething = true;
+            }
             if (cardsToDiscardorDraw > 0)
                 {
                     Player opponent = GameManager.Instance.GetOpponentOf(caster);


### PR DESCRIPTION
## Summary
- allow sorceries to randomly draw cards
- support random draw values in text and resolution
- add Rolling Insight blue sorcery

## Testing
- `No tests found`

------
https://chatgpt.com/codex/tasks/task_e_68852475a344832e8d942e67b69ae39e