### PR TITLE
Add Rolling Thunder card

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -74,6 +74,8 @@ public class CardData
     public SorceryCard.TargetType requiredTargetType = SorceryCard.TargetType.None;
     public bool excludeArtifactCreatures = false;
     public int damageToTarget = 0;
+    public int damageToTargetMin = 0;
+    public int damageToTargetMax = 0;
     public int powerBuff = 0;
     public int toughnessBuff = 0;
     public KeywordAbility keywordBuff = KeywordAbility.None;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2637,6 +2637,19 @@ public static class CardDatabase
                         artwork = Resources.Load<Sprite>("Art/fire_spirals"),
                         damageToEachCreatureAndPlayer = 2
                     });
+                Add(new CardData //Rolling Thunder
+                    {
+                        cardName = "Rolling Thunder",
+                        rarity = "Uncommon",
+                        cardType = CardType.Sorcery,
+                        manaCost = 4,
+                        color = new List<string> { "Red" },
+                        requiresTarget = true,
+                        requiredTargetType = SorceryCard.TargetType.CreatureOrPlayer,
+                        damageToTargetMin = 1,
+                        damageToTargetMax = 6,
+                        artwork = Resources.Load<Sprite>("Art/rolling_thunder"),
+                    });
             // GREEN
                 Add(new CardData //whip of thorns
                         {

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -67,6 +67,8 @@ public static class CardFactory
                 sorcery.requiresTarget = data.requiresTarget;
                 sorcery.requiredTargetType = data.requiredTargetType;
                 sorcery.damageToTarget = data.damageToTarget;
+                sorcery.damageToTargetMin = data.damageToTargetMin;
+                sorcery.damageToTargetMax = data.damageToTargetMax;
                 sorcery.destroyTargetIfTypeMatches = data.destroyTargetIfTypeMatches;
                 sorcery.destroyAllWithSameName = data.destroyAllWithSameName;
                 sorcery.keywordToGrant = data.keywordToGrant;

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1887,7 +1887,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             }
             if (sorcery.eachPlayerGainLifeEqualToLands)
                 rules += $"Each player gains life equal to the number of lands they control.\n";
-            if (sorcery.damageToTarget > 0 &&
+            if ((sorcery.damageToTarget > 0 || sorcery.damageToTargetMax > 0) &&
                 (sorcery.requiredTargetType == SorceryCard.TargetType.Creature ||
                 sorcery.requiredTargetType == SorceryCard.TargetType.Player ||
                 sorcery.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer))
@@ -1899,8 +1899,19 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     SorceryCard.TargetType.CreatureOrPlayer => "any target",
                     _ => "target"
                 };
-
-                rules += $"Deal {sorcery.damageToTarget} damage to {targetTypeStr}.\n";
+                if (sorcery.damageToTargetMax > 0)
+                {
+                    int min = sorcery.damageToTargetMin;
+                    int max = sorcery.damageToTargetMax;
+                    if (min == max)
+                        rules += $"Deal {min} damage to {targetTypeStr}.\n";
+                    else
+                        rules += $"Deal {min}-{max} damage to {targetTypeStr}.\n";
+                }
+                else
+                {
+                    rules += $"Deal {sorcery.damageToTarget} damage to {targetTypeStr}.\n";
+                }
             }
             if (sorcery.typeOfPermanentToDestroyAll != SorceryCard.PermanentTypeToDestroy.None)
             {

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -26,6 +26,8 @@ public class SorceryCard : Card
     public int cardsToDrawMax = 0;
     public Card chosenTarget = null;
     public int damageToTarget = 0;
+    public int damageToTargetMin = 0;
+    public int damageToTargetMax = 0;
     public bool destroyTargetIfTypeMatches = false;
     public bool destroyAllWithSameName = false;
     public KeywordAbility keywordToGrant = KeywordAbility.None;
@@ -343,7 +345,13 @@ public class SorceryCard : Card
                 if (target != null)
                 {
 
-                    if (damageToTarget > 0 && target is CreatureCard creature)
+                    int dmg = damageToTargetMax > 0
+                        ? (damageToTargetMin == damageToTargetMax
+                            ? damageToTargetMin
+                            : Random.Range(damageToTargetMin, damageToTargetMax + 1))
+                        : damageToTarget;
+
+                    if (dmg > 0 && target is CreatureCard creature)
                     {
                         KeywordAbility protection = ProtectionUtils.GetProtectionKeyword(PrimaryColor);
                         if (creature.keywordAbilities.Contains(protection))
@@ -352,7 +360,7 @@ public class SorceryCard : Card
                         }
                         else
                         {
-                            creature.toughness -= damageToTarget;
+                            creature.toughness -= dmg;
                             GameManager.Instance.CheckDeaths(GameManager.Instance.humanPlayer);
                             GameManager.Instance.CheckDeaths(GameManager.Instance.aiPlayer);
                         }
@@ -467,7 +475,7 @@ public class SorceryCard : Card
 
                     Debug.Log($"{minusTarget.cardName} receives {xValue} -1/-1 counters.");
                 }
-                else if (!destroyTargetIfTypeMatches && damageToTarget <= 0 && keywordToGrant == KeywordAbility.None)
+                else if (!destroyTargetIfTypeMatches && dmg <= 0 && keywordToGrant == KeywordAbility.None)
                 {
                     Debug.LogWarning($"{cardName} resolved on {target.cardName}, but did nothing.");
                 }
@@ -482,17 +490,23 @@ public class SorceryCard : Card
         {
             if (requiredTargetType == TargetType.Player || requiredTargetType == TargetType.CreatureOrPlayer)
             {
-                if (damageToTarget > 0)
+                int dmg = damageToTargetMax > 0
+                    ? (damageToTargetMin == damageToTargetMax
+                        ? damageToTargetMin
+                        : Random.Range(damageToTargetMin, damageToTargetMax + 1))
+                    : damageToTarget;
+
+                if (dmg > 0)
                 {
-                    targetPlayer.Life -= damageToTarget;
-                    Debug.Log($"{cardName} deals {damageToTarget} damage to {targetPlayer}.");
+                    targetPlayer.Life -= dmg;
+                    Debug.Log($"{cardName} deals {dmg} damage to {targetPlayer}.");
 
                     GameObject targetUI = (targetPlayer == GameManager.Instance.humanPlayer)
                         ? GameManager.Instance.playerLifeContainer
                         : GameManager.Instance.enemyLifeContainer;
 
                     GameManager.Instance.CheckForGameEnd();
-                    GameManager.Instance.ShowFloatingDamage(damageToTarget, targetUI);
+                    GameManager.Instance.ShowFloatingDamage(dmg, targetUI);
                 }
             }
 

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -552,11 +552,11 @@ public class TurnSystem : MonoBehaviour
                                             }
                                         }
 
-                                        bool canTarget = sorcery.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer && sorcery.damageToTarget > 0;
+                                        bool canTarget = sorcery.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer && (sorcery.damageToTarget > 0 || sorcery.damageToTargetMax > 0);
 
                                         if (canTarget)
                                         {
-                                            int damage = sorcery.damageToTarget;
+                                            int damage = sorcery.damageToTargetMax > 0 ? sorcery.damageToTargetMax : sorcery.damageToTarget;
                                             Player opponent = GameManager.Instance.humanPlayer;
 
                                             // Get enemy creatures


### PR DESCRIPTION
## Summary
- add `damageToTargetMin/Max` fields to card data and sorcery
- implement random damage handling and display
- update AI targeting logic for variable damage
- create new "Rolling Thunder" sorcery in card database

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688526851e7c832eb1cf5c658c0274f1