### PR TITLE
Add Cloud Leviathan creature card

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2303,6 +2303,23 @@ public static class CardDatabase
                         }
                     }
                     });
+                Add(new CardData //Cloud Leviathan
+                    {
+                    cardName = "Cloud Leviathan",
+                    rarity = "Common",
+                    manaCost = 2,
+                    color = new List<string> { "White", "Blue" },
+                    cardType = CardType.Creature,
+                    power = 0,
+                    toughness = 6,
+                    subtypes = new List<string> { "Leviathan" },
+                    keywordAbilities = new List<KeywordAbility>
+                    {
+                        KeywordAbility.Defender,
+                        KeywordAbility.Flying
+                    },
+                    artwork = Resources.Load<Sprite>("Art/cloud_leviathan")
+                    });
         // Sorceries
             //WHITE
                 Add(new CardData { //Exorcism


### PR DESCRIPTION
## Summary
- create new common multicolor creature **Cloud Leviathan**
- card costs 2 mana (white and blue) and has 0 power, 6 toughness
- includes Defender and Flying keyword abilities

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68852c0f4814832e8ede1430c606bbe6