### PR TITLE
Fix victory screen card hover

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -65,6 +65,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
     private readonly Vector2 defaultStatsPosition = new Vector2(28, -53);
     private Vector3 originalPosition;
 
+    // When true, hovering the card will not move it or show a preview
+    public bool disableHoverEffects = false;
     public bool isInBattlefield = false;
     public bool isInGraveyard = false;
     public bool isInGraveyardViewer = false; // true when shown in the Graveyard UI
@@ -81,6 +83,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
         public void OnPointerEnter(PointerEventData eventData)
         {
+            if (disableHoverEffects)
+                return;
+
             if ((isInGraveyard && !isInGraveyardViewer) || isInStack || linkedCard == null || linkedCard.artwork == null)
                 return;
 
@@ -110,6 +115,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
         public void OnPointerExit(PointerEventData eventData)
         {
+            if (disableHoverEffects)
+                return;
+
             if ((isInGraveyard && !isInGraveyardViewer) || isInStack)
                 return;
 

--- a/Assets/Scripts/WinScreenUI.cs
+++ b/Assets/Scripts/WinScreenUI.cs
@@ -74,6 +74,7 @@ public class WinScreenUI : MonoBehaviour
             Card cardObj = CardFactory.Create(wonCard.cardName);
             var visual = spawnedCardVisual.GetComponent<CardVisual>();
             visual.Setup(cardObj, null, wonCard);
+            visual.disableHoverEffects = true;
             spawnedCardVisual.transform.localScale = Vector3.one * 2f;
 
             if (wonCardImage != null)


### PR DESCRIPTION
## Summary
- add `disableHoverEffects` flag to `CardVisual`
- use flag for card displayed in `WinScreenUI`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885fa055f28832eab3eb626e2ef5865