### PR TITLE
Limit color selection to a single choice

### DIFF
--- a/Assets/Scripts/ColorButtonBehavior.cs
+++ b/Assets/Scripts/ColorButtonBehavior.cs
@@ -33,7 +33,7 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
     public AudioClip clickSound;
     public AudioClip unclickSound;
 
-    // Up to two colors can be selected at a time
+    // Only one color can be selected at a time
     private static List<ColorButtonBehavior> selectedColors = new List<ColorButtonBehavior>();
     private static Image backgroundPanelStatic;
     private static Color targetBGColor;
@@ -119,7 +119,7 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
             }
             else
             {
-                if (selectedColors.Count >= 2)
+                if (selectedColors.Count >= 1)
                 {
                     var first = selectedColors[0];
                     first.isSelected = false;


### PR DESCRIPTION
## Summary
- restrict color selection to only one color in `ColorButtonBehavior`
- update relevant comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ba6c94b0832e9a71325f9bfe8654