### PR TITLE
Reset favourite star when removed card is deleted

### DIFF
--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -223,6 +223,14 @@ public class DeckEditorManager : MonoBehaviour
         if (!deck.Remove(data))
             return;
 
+        // If the removed card was favourited, reset the favourite star
+        if (FavouriteCard != null && FavouriteCard.cardName == data.cardName)
+        {
+            FavouriteCardManager star = FindObjectOfType<FavouriteCardManager>();
+            if (star != null)
+                star.ReturnToStart();
+        }
+
         collection.Add(data);
         PlayerCollection.OwnedCards.Add(data);
         Destroy(visual);

--- a/Assets/Scripts/FavouriteCardManager.cs
+++ b/Assets/Scripts/FavouriteCardManager.cs
@@ -158,7 +158,8 @@ public class FavouriteCardManager : MonoBehaviour, IBeginDragHandler, IDragHandl
         hoverRoutine = null;
     }
 
-    private void ReturnToStart()
+    // Reset the favourite star back to its start position
+    public void ReturnToStart()
     {
         rectTransform.SetParent(startParent, true);
         rectTransform.localPosition = startPosition;


### PR DESCRIPTION
## Summary
- return the favourite star to its start position when the starred card is removed from the deck
- expose `ReturnToStart` in `FavouriteCardManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c52d2090832e80a535fc472882d1