### PR TITLE
Prevent tapped creatures from being deselected by repeat "Attack All" presses

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1643,7 +1643,12 @@ public class TurnSystem : MonoBehaviour
                 if (GameManager.Instance.graveyardViewActive)
                     return;
 
-                GameManager.Instance.selectedAttackers.Clear();
+                // Clear any previously selected attackers so the function is idempotent
+                // This prevents creatures from staying tapped without being
+                // registered as attackers if the button is pressed multiple
+                // times in the same combat step
+                ClearAllSelectedAttackers();
+
                 bool anyDeclared = false;
 
                 foreach (var card in GameManager.Instance.humanPlayer.Battlefield)


### PR DESCRIPTION
## Summary
- ensure `SelectAllEligibleAttackers` clears any current selection first

This makes pressing the `Attack All` button multiple times safe. Previously, a second press would clear the list and ignore already tapped creatures, causing them to stay tapped but not attack.

## Testing
- `grep -n "SelectAllEligibleAttackers" -n -A 5 -B 5 Assets/Scripts/TurnSystem.cs`

------
https://chatgpt.com/codex/tasks/task_e_6887c682322c832ea1fe5aa9dc2ac82e