### PR TITLE
Restore dual color selection

### DIFF
--- a/Assets/Scripts/ColorButtonBehavior.cs
+++ b/Assets/Scripts/ColorButtonBehavior.cs
@@ -33,7 +33,7 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
     public AudioClip clickSound;
     public AudioClip unclickSound;
 
-    // Only one color can be selected at a time
+    // Up to two colors can be selected at a time
     private static List<ColorButtonBehavior> selectedColors = new List<ColorButtonBehavior>();
     private static Image backgroundPanelStatic;
     private static Color targetBGColor;
@@ -119,7 +119,7 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
             }
             else
             {
-                if (selectedColors.Count >= 1)
+                if (selectedColors.Count >= 2)
                 {
                     var first = selectedColors[0];
                     first.isSelected = false;


### PR DESCRIPTION
## Summary
- allow selecting up to two colours again in `ColorButtonBehavior`
- keep both descriptions visible when two colours are chosen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ce917424832eb3b3d382f17db539