### PR TITLE
Fix Feast life gain message

### DIFF
--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -200,9 +200,6 @@ public class SorceryCard : Card
                     GameManager.Instance.TryGainLife(human, humanLands);
                     GameManager.Instance.TryGainLife(ai, aiLands);
 
-                    GameManager.Instance.ShowFloatingHeal(humanLands, GameManager.Instance.playerLifeContainer);
-                    GameManager.Instance.ShowFloatingHeal(aiLands, GameManager.Instance.enemyLifeContainer);
-
                     Debug.Log($"Each player gains life equal to their own lands. Human: +{humanLands}, AI: +{aiLands}");
                     didSomething = true;
                 }


### PR DESCRIPTION
## Summary
- remove duplicate floating heal calls in `SorceryCard`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888c0fe64f4832eaa9e6e98fdfc647b