### PR TITLE
Fix aura damage interaction

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2291,7 +2291,7 @@ public static class CardDatabase
                                 }
                                 else if (target is CreatureCard creature)
                                 {
-                                    creature.toughness -= 2;
+                                    creature.TakeDamage(2);
                                     var vis = GameManager.Instance.FindCardVisual(creature);
                                     if (vis != null)
                                         GameManager.Instance.ShowFloatingDamage(2, vis.gameObject);

--- a/Assets/Scripts/CreatureCard.cs
+++ b/Assets/Scripts/CreatureCard.cs
@@ -19,7 +19,29 @@ public class CreatureCard : Card
     public void RecalculateStats()
     {
         power = basePower + plusOneCounters - minusOneCounters + tempPowerBonus + auraPowerBonus;
-        toughness = baseToughness + plusOneCounters - minusOneCounters + tempToughnessBonus + auraToughnessBonus;
+        toughness = baseToughness + plusOneCounters - minusOneCounters + tempToughnessBonus + auraToughnessBonus - damageTaken;
+    }
+
+    public void TakeDamage(int amount)
+    {
+        if (amount <= 0) return;
+        damageTaken += amount;
+        RecalculateStats();
+    }
+
+    public void ResetDamage()
+    {
+        if (damageTaken != 0)
+        {
+            damageTaken = 0;
+            RecalculateStats();
+        }
+    }
+
+    public void Kill()
+    {
+        damageTaken = baseToughness + plusOneCounters - minusOneCounters + tempToughnessBonus + auraToughnessBonus;
+        RecalculateStats();
     }
 
     public void AddPlusOneCounter()
@@ -119,6 +141,7 @@ public class CreatureCard : Card
         plusOneCounters = 0;
         minusOneCounters = 0;
         ResetTemporaryBuff();
+        ResetDamage();
         RecalculateStats();
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -734,9 +734,9 @@ public class GameManager : MonoBehaviour
                     if (!blockerProtected)
                     {
                         damageToBlocker = Mathf.Min(remainingDamage, blocker.toughness);
-                        blocker.toughness -= damageToBlocker;
+                        blocker.TakeDamage(damageToBlocker);
                         if (attacker.keywordAbilities.Contains(KeywordAbility.Deathtouch) && damageToBlocker > 0)
-                            blocker.toughness = 0;
+                            blocker.Kill();
                         remainingDamage -= damageToBlocker;
                     }
 
@@ -745,7 +745,7 @@ public class GameManager : MonoBehaviour
                     {
                         totalDamageFromBlockers += damageFromBlocker;
                         if (blocker.keywordAbilities.Contains(KeywordAbility.Deathtouch) && damageFromBlocker > 0)
-                            attacker.toughness = 0;
+                            attacker.Kill();
                     }
 
                     if (damageToBlocker > 0 || damageFromBlocker > 0)
@@ -768,7 +768,7 @@ public class GameManager : MonoBehaviour
                     }
                 }
 
-                attacker.toughness -= totalDamageFromBlockers;
+                attacker.TakeDamage(totalDamageFromBlockers);
 
                 if (attacker.keywordAbilities.Contains(KeywordAbility.Trample) && remainingDamage > 0)
                 {
@@ -932,7 +932,7 @@ public class GameManager : MonoBehaviour
         {
             if (card is CreatureCard creature)
             {
-                creature.RecalculateStats();
+                creature.ResetDamage();
             }
         }
     }
@@ -2192,13 +2192,13 @@ public class GameManager : MonoBehaviour
                         return;
                     }
 
-                targetCreature.toughness -= targetingArtifact.damageToCreature;
+                targetCreature.TakeDamage(targetingArtifact.damageToCreature);
                 Card asCard = targetingArtifact;
                 if (asCard is CreatureCard srcCreature &&
                     srcCreature.keywordAbilities.Contains(KeywordAbility.Deathtouch) &&
                     targetingArtifact.damageToCreature > 0)
                 {
-                    targetCreature.toughness = 0;
+                    targetCreature.Kill();
                 }
                 Debug.Log($"{targetingArtifact.cardName} deals {targetingArtifact.damageToCreature} to {targetCreature.cardName}");
 
@@ -2656,13 +2656,13 @@ public class GameManager : MonoBehaviour
                 GetOwnerOfCard(creature)?.Battlefield.Contains(creature) == true &&
                 targetingArtifact != null)
             {
-                creature.toughness -= targetingArtifact.damageToCreature;
+                creature.TakeDamage(targetingArtifact.damageToCreature);
                 Card asCard = targetingArtifact;
                 if (asCard is CreatureCard srcCreature &&
                     srcCreature.keywordAbilities.Contains(KeywordAbility.Deathtouch) &&
                     targetingArtifact.damageToCreature > 0)
                 {
-                    creature.toughness = 0;
+                    creature.Kill();
                 }
                 Debug.Log($"{targetingArtifact.cardName} dealt {targetingArtifact.damageToCreature} damage to {creature.cardName}");
                 targetingArtifact.isTapped = true;
@@ -3070,9 +3070,9 @@ public class GameManager : MonoBehaviour
                         if (!blockerProtected)
                         {
                             damageToBlocker = Mathf.Min(remainingDamage, blocker.toughness);
-                            blocker.toughness -= damageToBlocker;
+                            blocker.TakeDamage(damageToBlocker);
                             if (attacker.keywordAbilities.Contains(KeywordAbility.Deathtouch) && damageToBlocker > 0)
-                                blocker.toughness = 0;
+                                blocker.Kill();
                             remainingDamage -= damageToBlocker;
                         }
 
@@ -3081,7 +3081,7 @@ public class GameManager : MonoBehaviour
                         {
                             totalDamageFromBlockers += damageFromBlocker;
                             if (blocker.keywordAbilities.Contains(KeywordAbility.Deathtouch) && damageFromBlocker > 0)
-                                attacker.toughness = 0;
+                                attacker.Kill();
                         }
 
                         if (damageToBlocker > 0 || damageFromBlocker > 0)
@@ -3100,7 +3100,7 @@ public class GameManager : MonoBehaviour
                         }
                     }
 
-                    attacker.toughness -= totalDamageFromBlockers;
+                    attacker.TakeDamage(totalDamageFromBlockers);
 
                     if (attacker.keywordAbilities.Contains(KeywordAbility.Trample) && remainingDamage > 0)
                     {

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -303,7 +303,7 @@ public class SorceryCard : Card
                                 continue;
                             }
 
-                            creature.toughness -= damageToEachCreatureAndPlayer;
+                            creature.TakeDamage(damageToEachCreatureAndPlayer);
                         }
                     }
 
@@ -358,7 +358,7 @@ public class SorceryCard : Card
                     }
                     else
                     {
-                        creature.toughness -= dmg;
+                        creature.TakeDamage(dmg);
                         GameManager.Instance.CheckDeaths(GameManager.Instance.humanPlayer);
                         GameManager.Instance.CheckDeaths(GameManager.Instance.aiPlayer);
                     }


### PR DESCRIPTION
## Summary
- track damage taken separately so negative auras respect current wounds
- apply damage using new `TakeDamage`/`Kill` helpers
- clear damage when creatures leave play or at end of turn

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888c73e2854832e8a8c7cb54804e97b