### PR TITLE
Fix AI ETB targeting persistence

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -67,7 +67,10 @@ public class Card
 
                 if (ability.requiresTarget)
                 {
-                    GameManager.Instance.BeginOptionalTargetSelectionAfterEntry(this, owner, ability);
+                    // Only initiate optional targeting for the human player's cards.
+                    // AI-controlled cards handle their ETB targeting automatically.
+                    if (owner == GameManager.Instance.humanPlayer)
+                        GameManager.Instance.BeginOptionalTargetSelectionAfterEntry(this, owner, ability);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- avoid setting optional ETB targeting when the creature is controlled by AI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688919cda3a4832e97fdeac64bc49575