### PR TITLE
Raise merchant card position

### DIFF
--- a/Assets/Scripts/MerchantManager.cs
+++ b/Assets/Scripts/MerchantManager.cs
@@ -86,6 +86,10 @@ public class MerchantManager : MonoBehaviour
         Card card = CardFactory.Create(slot.cardData.cardName);
         GameObject go = Instantiate(cardPrefab, buttonTransform);
         go.transform.localScale = Vector3.one * 3f;
+        // Place the card slightly higher in the merchant room so it is
+        // easier to see. 65 units on the Y axis gives a better visual
+        // alignment for the prefab in each slot.
+        go.transform.localPosition = new Vector3(0f, 65f, 0f);
         var visual = go.GetComponent<CardVisual>();
         visual.Setup(card, null, slot.cardData);
         visual.disableHoverEffects = true;


### PR DESCRIPTION
## Summary
- adjust card prefab Y offset in `MerchantManager` so cards appear higher in merchant room

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a47089454832eb4a81d632e8f8fb7