### PR TITLE
Fix SoundManager to ensure audio clips load across scenes

### DIFF
--- a/Assets/Scripts/SoundManager.cs
+++ b/Assets/Scripts/SoundManager.cs
@@ -41,6 +41,28 @@ public class SoundManager : MonoBehaviour
 
         DontDestroyOnLoad(gameObject);
         audioSource = gameObject.AddComponent<AudioSource>();
+
+        // Automatically load clips if they were not assigned in the inspector.
+        if (buttonClick == null)      buttonClick = Resources.Load<AudioClip>("Audio/SFX/click");
+        if (cardPlay == null)         cardPlay = Resources.Load<AudioClip>("Audio/SFX/play");
+        if (playCreature == null)     playCreature = Resources.Load<AudioClip>("Audio/SFX/play_creature");
+        if (playArtifact == null)     playArtifact = Resources.Load<AudioClip>("Audio/SFX/play_artifact");
+        if (declareAttack == null)    declareAttack = Resources.Load<AudioClip>("Audio/SFX/attack");
+        if (declareBlock == null)     declareBlock = Resources.Load<AudioClip>("Audio/SFX/block_combat");
+        if (break_artifact == null)   break_artifact = Resources.Load<AudioClip>("Audio/SFX/break_artifact");
+        if (tap_for_mana == null)     tap_for_mana = Resources.Load<AudioClip>("Audio/SFX/tap_for_mana");
+        if (plague == null)           plague = Resources.Load<AudioClip>("Audio/SFX/plague");
+        if (dealDamage == null)       dealDamage = Resources.Load<AudioClip>("Audio/SFX/snd_damage_low");
+        if (impact == null)           impact = Resources.Load<AudioClip>("Audio/SFX/impact");
+        if (drink == null)            drink = Resources.Load<AudioClip>("Audio/SFX/drink");
+        if (miner == null)            miner = Resources.Load<AudioClip>("Audio/SFX/miner");
+        if (gain_life == null)        gain_life = Resources.Load<AudioClip>("Audio/SFX/heal");
+        if (victory == null)          victory = Resources.Load<AudioClip>("Audio/SFX/Victory");
+        if (defeat == null)           defeat = Resources.Load<AudioClip>("Audio/SFX/Defeat");
+        if (drawCard == null)         drawCard = Resources.Load<AudioClip>("Audio/SFX/draw_card");
+        if (turnChange == null)       turnChange = Resources.Load<AudioClip>("Audio/SFX/nextturn_sfx");
+        if (equipArtifact == null)    equipArtifact = Resources.Load<AudioClip>("Audio/SFX/equip_sfx");
+        if (buyCard == null)          buyCard = Resources.Load<AudioClip>("Audio/SFX/buy_sfx");
     }
 
     public void PlaySound(AudioClip clip)


### PR DESCRIPTION
## Summary
- add automatic Resource loading to SoundManager so missing clip references no longer break sound playback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b6ae81578832e9426664789ccd6ec