### PR TITLE
Exclude basic lands from merchant common slot

### DIFF
--- a/Assets/Scripts/MerchantManager.cs
+++ b/Assets/Scripts/MerchantManager.cs
@@ -181,8 +181,9 @@ public class MerchantManager : MonoBehaviour
 
     private CardData GetRandomCardByRarity(string rarity)
     {
+        string[] basicLands = { "Plains", "Island", "Swamp", "Mountain", "Forest" };
         var pool = CardDatabase.GetAllCards()
-            .Where(c => c.rarity == rarity && !c.isToken)
+            .Where(c => c.rarity == rarity && !c.isToken && !basicLands.Contains(c.cardName))
             .ToList();
         if (pool.Count == 0)
             return null;


### PR DESCRIPTION
## Summary
- prevent Merchant common slot from selecting basic lands

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688e2e1bb4d4832ea94bc63c9719f421