### PR TITLE
Group basic lands in deck editor and viewer

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -94,4 +94,20 @@ public class CardData
     public List<ActivatedAbility> activatedAbilities = new List<ActivatedAbility>();
 
     // Future: active effects like "on enter" or "on death"
-    public List<CardAbility> abilities = new List<CardAbility>();}
+    public List<CardAbility> abilities = new List<CardAbility>();
+
+    public static bool IsBasicLand(CardData card)
+    {
+        if (card == null)
+            return false;
+
+        if (card.cardType != CardType.Land)
+            return false;
+
+        return card.cardName == "Plains" ||
+               card.cardName == "Island" ||
+               card.cardName == "Swamp" ||
+               card.cardName == "Mountain" ||
+               card.cardName == "Forest";
+    }
+}

--- a/Assets/Scripts/DeckEditorCardButton.cs
+++ b/Assets/Scripts/DeckEditorCardButton.cs
@@ -1,25 +1,68 @@
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 public class DeckEditorCardButton : MonoBehaviour
 {
     public CardData Data { get; private set; }
     private DeckEditorManager manager;
 
-    public void Initialize(CardData data, DeckEditorManager mgr)
+    public int Count { get; private set; } = 1;
+    private TMP_Text countLabel;
+
+    public void Initialize(CardData data, DeckEditorManager mgr, int count = 1)
     {
         Data = data;
         manager = mgr;
+        Count = count;
+
         var btn = GetComponent<Button>();
-        if (btn != null)
+        if (btn != null && manager != null)
         {
             btn.onClick.RemoveAllListeners();
             btn.onClick.AddListener(OnClick);
         }
+
+        SetupLabel();
+        UpdateLabel();
+    }
+
+    private void SetupLabel()
+    {
+        if (countLabel != null)
+            return;
+
+        GameObject labelObj = new GameObject("CountLabel");
+        labelObj.transform.SetParent(transform, false);
+        countLabel = labelObj.AddComponent<TextMeshProUGUI>();
+        countLabel.alignment = TextAlignmentOptions.TopRight;
+        RectTransform rt = countLabel.rectTransform;
+        rt.anchorMin = new Vector2(1, 1);
+        rt.anchorMax = new Vector2(1, 1);
+        rt.pivot = new Vector2(1, 1);
+        rt.anchoredPosition = new Vector2(-10, -10);
+    }
+
+    public void Increment()
+    {
+        Count++;
+        UpdateLabel();
+    }
+
+    public void Decrement()
+    {
+        Count--;
+        UpdateLabel();
+    }
+
+    public void UpdateLabel()
+    {
+        if (countLabel != null)
+            countLabel.text = Count > 1 ? Count.ToString() : string.Empty;
     }
 
     private void OnClick()
     {
-        manager?.OnCardClicked(Data, gameObject);
+        manager?.OnCardClicked(this);
     }
 }


### PR DESCRIPTION
## Summary
- add CardData.IsBasicLand helper
- group basic lands with count overlays in deck editor and deck viewer
- support incrementing/decrementing grouped land counts on add/remove

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e3b063dfc832e8d3d924040937796