### PR TITLE
Fix duplicate win screen after self-destructive loss

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -3657,17 +3657,24 @@ public class GameManager : MonoBehaviour
 
         public void CheckForGameEnd()
         {
+            if (gameOver)
+                return;
+
             if (aiPlayer.Life <= 0)
             {
                 Debug.Log("AI defeated — player wins!");
                 CardData reward = PlayerCollection.AddRandomCard();
                 gameOver = true;
+                if (TurnSystem.Instance != null)
+                    TurnSystem.Instance.StopAllCoroutines();
                 FindObjectOfType<WinScreenUI>().ShowWinScreen(reward);
             }
             else if (humanPlayer.Life <= 0)
             {
                 Debug.Log("Human player defeated — game lost.");
                 gameOver = true;
+                if (TurnSystem.Instance != null)
+                    TurnSystem.Instance.StopAllCoroutines();
                 FindObjectOfType<WinScreenUI>().ShowLoseScreen();
             }
         }


### PR DESCRIPTION
## Summary
- prevent repeated win screen triggers by skipping game over logic if the match has already ended
- stop turn system coroutines when the game ends so phases cannot progress after defeat

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f68c89698832e9a8d05afc70f950f