### PR TITLE
Fix aura card text hidden in graveyard

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1768,6 +1768,15 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 costBackground.SetActive(true);
                 statsBackground.SetActive(false);
             }
+            else if (linkedCard is EnchantmentCard enchantment)
+            {
+                costText.text = Mathf.Max(enchantment.manaCost - linkedCard.color.Count, 0).ToString();
+                statsText.text = "";
+                keywordText.text = linkedCard.GetCardText();
+
+                costBackground.SetActive(true);
+                statsBackground.SetActive(false);
+            }
             else if (linkedCard is LandCard)
             {
                 costText.text = "";


### PR DESCRIPTION
## Summary
- show enchantment/aura card text when viewing the graveyard

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fd83279f8832e9653c60b74d2b4fb