### PR TITLE
fix: prevent deck editor hover misalignment

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -74,6 +74,16 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
     private bool isPointerOver = false;
 
+    void Awake()
+    {
+        if (highlightBorder != null)
+        {
+            var img = highlightBorder.GetComponent<Image>();
+            if (img != null)
+                img.raycastTarget = false;
+        }
+    }
+
     void Start()
         {
             if (SceneManager.GetActiveScene().name == "DeckEditorScene")


### PR DESCRIPTION
## Summary
- ensure deck editor highlight border doesn't intercept cursor events

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688fe22f0f54832eb49f9d1e81dadeba