### PR TITLE
Limit hover detection to visible logo area

### DIFF
--- a/Assets/Scripts/ColorButtonBehavior.cs
+++ b/Assets/Scripts/ColorButtonBehavior.cs
@@ -55,6 +55,17 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
 
     void Start()
         {
+            Image img = GetComponent<Image>();
+            if (img != null)
+            {
+                img.alphaHitTestMinimumThreshold = 0.1f;
+            }
+
+            if (hoverGlow != null)
+                hoverGlow.raycastTarget = false;
+            if (selectionGlow != null)
+                selectionGlow.raycastTarget = false;
+
             SetAlpha(hoverGlow, 0f);
             SetAlpha(selectionGlow, 0f);
 


### PR DESCRIPTION
## Summary
- restrict color logo hover events to opaque pixels
- prevent hover/selection glows from intercepting mouse events

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890c2534e2c832e8e4b488991aeb684