### PR TITLE
Fix stray brace breaking AI main phase logic

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -641,8 +641,7 @@ public class TurnSystem : MonoBehaviour
 
                                         playedCard = true;
                                         break;
-                                    }   
-                                }
+                                    }
                                 else if (card is ArtifactCard artifact)
                                 {
                                     var cost = GameManager.Instance.GetManaCostBreakdown(artifact.manaCost, artifact.color);


### PR DESCRIPTION
## Summary
- remove misplaced closing brace in TurnSystem.cs that broke the `else if` chain for AI card handling

## Testing
- `mcs Assets/Scripts/TurnSystem.cs` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891103b3e60832ea5107a707bedc549