### PR TITLE
Fix card hover area in deck editor

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -76,12 +76,34 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
     void Awake()
     {
-        if (highlightBorder != null)
-        {
-            var img = highlightBorder.GetComponent<Image>();
-            if (img != null)
-                img.raycastTarget = false;
-        }
+        DisableRaycast(highlightBorder);
+        DisableRaycast(artImage);
+        DisableRaycast(cardRarity);
+        DisableRaycast(coloredManaIcon1);
+        DisableRaycast(coloredManaIcon2);
+        DisableRaycast(costBackground);
+        DisableRaycast(statsBackground);
+        DisableRaycast(swordIcon);
+        DisableRaycast(shieldIcon);
+        DisableRaycast(tapIcon);
+        DisableRaycast(genericCostBG);
+        DisableRaycast(landIcon);
+        DisableRaycast(counterImage);
+    }
+
+    private void DisableRaycast(Image img)
+    {
+        if (img != null)
+            img.raycastTarget = false;
+    }
+
+    private void DisableRaycast(GameObject obj)
+    {
+        if (obj == null)
+            return;
+        var img = obj.GetComponent<Image>();
+        if (img != null)
+            img.raycastTarget = false;
     }
 
     void Start()


### PR DESCRIPTION
## Summary
- Ensure card hover works over art by disabling raycast targets on decorative images

## Testing
- `dotnet test` (command not found)
- `npm test` (package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_68911860e260832ebb42261f5e8e219f