### PR TITLE
Ignore raycasts on card artwork

### DIFF
--- a/Assets/Resources/Prefab/CardPrefab.prefab
+++ b/Assets/Resources/Prefab/CardPrefab.prefab
@@ -57,8 +57,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1792,11 +1792,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -77,7 +77,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
     void Awake()
     {
         DisableRaycast(highlightBorder);
+
+        if (artImage == null)
+            artImage = GetComponentInChildren<Image>(true);
         DisableRaycast(artImage);
+
         DisableRaycast(cardRarity);
         DisableRaycast(coloredManaIcon1);
         DisableRaycast(coloredManaIcon2);


### PR DESCRIPTION
## Summary
- Ensure `CardVisual` finds the artwork image and disables its raycasts
- Turn off raycasting on card art in `CardPrefab`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_6891f16b6ba0832e9cc18a9865af064c