### PR TITLE
Ignore raycasts on card artwork

### DIFF
--- a/Assets/Resources/Prefab/CardPrefab.prefab
+++ b/Assets/Resources/Prefab/CardPrefab.prefab
@@ -57,8 +57,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1792,11 +1792,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -77,7 +77,12 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
     void Awake()
     {
         DisableRaycast(highlightBorder);
+
+        if (artImage == null)
+            artImage = GetComponentsInChildren<Image>(true)
+                .FirstOrDefault(i => i.gameObject.name.ToLower().Contains("art"));
         DisableRaycast(artImage);
+
         DisableRaycast(cardRarity);
         DisableRaycast(coloredManaIcon1);
         DisableRaycast(coloredManaIcon2);

--- a/Assets/Scripts/DeckEditorCardButton.cs
+++ b/Assets/Scripts/DeckEditorCardButton.cs
@@ -36,11 +36,13 @@ public class DeckEditorCardButton : MonoBehaviour
         labelObj.transform.SetParent(transform, false);
         countLabel = labelObj.AddComponent<TextMeshProUGUI>();
         countLabel.alignment = TextAlignmentOptions.TopRight;
+        countLabel.raycastTarget = false;
         RectTransform rt = countLabel.rectTransform;
         rt.anchorMin = new Vector2(1, 1);
         rt.anchorMax = new Vector2(1, 1);
         rt.pivot = new Vector2(1, 1);
         rt.anchoredPosition = new Vector2(-10, -10);
+        rt.sizeDelta = Vector2.zero;
     }
 
     public void Increment()


### PR DESCRIPTION
## Summary
- Ensure `CardVisual` finds card artwork by name and disables its raycasts
- Prevent deck editor card count label from blocking clicks

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891f16b6ba0832e9cc18a9865af064c