### PR TITLE
Fix deck editor card hover

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -79,7 +79,20 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
         DisableRaycast(highlightBorder);
 
         if (artImage == null)
-            artImage = GetComponentInChildren<Image>(true);
+        {
+            foreach (var img in GetComponentsInChildren<Image>(true))
+            {
+                string name = img.gameObject.name.ToLower();
+                if (name == "artimage" || name == "artwork" || name == "art")
+                {
+                    artImage = img;
+                    break;
+                }
+            }
+
+            if (artImage == null)
+                artImage = GetComponentInChildren<Image>(true);
+        }
         DisableRaycast(artImage);
 
         DisableRaycast(cardRarity);

--- a/Assets/Scripts/DeckEditorCardButton.cs
+++ b/Assets/Scripts/DeckEditorCardButton.cs
@@ -36,6 +36,7 @@ public class DeckEditorCardButton : MonoBehaviour
         labelObj.transform.SetParent(transform, false);
         countLabel = labelObj.AddComponent<TextMeshProUGUI>();
         countLabel.alignment = TextAlignmentOptions.TopRight;
+        countLabel.raycastTarget = false;
         RectTransform rt = countLabel.rectTransform;
         rt.anchorMin = new Vector2(1, 1);
         rt.anchorMax = new Vector2(1, 1);


### PR DESCRIPTION
## Summary
- ensure deck editor card art doesn't block hover by locating and disabling its raycasts
- ensure deck editor card count label doesn't block hover interactions

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f9aa2170832ebd9b7d3980d19513