### PR TITLE
Handle draws as losses

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -3687,7 +3687,15 @@ public class GameManager : MonoBehaviour
             if (gameOver)
                 return;
 
-            if (aiPlayer.Life <= 0)
+            if (aiPlayer.Life <= 0 && humanPlayer.Life <= 0)
+            {
+                Debug.Log("Both players died — draw counts as a loss for the human player.");
+                gameOver = true;
+                if (TurnSystem.Instance != null)
+                    TurnSystem.Instance.StopAllCoroutines();
+                FindObjectOfType<WinScreenUI>().ShowLoseScreen();
+            }
+            else if (aiPlayer.Life <= 0)
             {
                 Debug.Log("AI defeated — player wins!");
                 CardData reward = PlayerCollection.AddRandomCard();


### PR DESCRIPTION
## Summary
- Treat simultaneous defeats as losses for the human player instead of wins

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68934ae0f2d0832e86fcbc223d935ee6