### PR TITLE
Add Lich Queen rare creature card

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2320,6 +2320,24 @@ public static class CardDatabase
                     },
                     artwork = Resources.Load<Sprite>("Art/cloudmane_leviathan")
                     });
+                Add(new CardData //Lich Queen
+                    {
+                    cardName = "Lich Queen",
+                    rarity = "Rare",
+                    manaCost = 4,
+                    color = new List<string> { "Black", "White" },
+                    cardType = CardType.Creature,
+                    power = 2,
+                    toughness = 4,
+                    subtypes = new List<string> { "Zombie" },
+                    keywordAbilities = new List<KeywordAbility>
+                    {
+                        KeywordAbility.Vigilance,
+                        KeywordAbility.Indestructible,
+                        KeywordAbility.Lifelink
+                    },
+                    artwork = Resources.Load<Sprite>("Art/lich_queen")
+                    });
         // Sorceries
             //WHITE
                 Add(new CardData { //Exorcism


### PR DESCRIPTION
## Summary
- add Lich Queen, a rare black/white Zombie with vigilance, indestructible, and lifelink to the card database

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a951e6588327b845738dc2665397