### PR TITLE
Spawn creature entry VFX

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1668,6 +1668,33 @@ public class GameManager : MonoBehaviour
         CheckForGameEnd();
     }
 
+    public void ShowCreatureEnterVFX(CreatureCard creature)
+    {
+        CardVisual visual = FindCardVisual(creature);
+        if (visual == null)
+        {
+            Debug.LogWarning("No visual found for creature " + creature.cardName);
+            return;
+        }
+
+        Vector3 spawnPos = visual.artImage != null ? visual.artImage.transform.position : visual.transform.position;
+        spawnPos.z = 0f;
+
+        Sprite sprite = Resources.Load<Sprite>("VFX/onenter");
+        if (sprite == null)
+        {
+            Debug.LogWarning("Missing onenter sprite in Resources/VFX");
+            return;
+        }
+
+        GameObject vfx = new GameObject("CreatureEnterVFX");
+        var sr = vfx.AddComponent<SpriteRenderer>();
+        sr.sprite = sprite;
+        sr.sortingOrder = 10;
+        vfx.transform.position = spawnPos;
+        Destroy(vfx, 1.5f);
+    }
+
     public void ShowBloodSplatVFX(Card card)
     {
         Debug.Log("ShowBloodSplatVFX triggered on: " + card.cardName);
@@ -3483,6 +3510,7 @@ public class GameManager : MonoBehaviour
             if (!(creature is CreatureCard))
                 return;
 
+            ShowCreatureEnterVFX((CreatureCard)creature);
             lastEnteredCreature = creature;
             foreach (var player in new[] { humanPlayer, aiPlayer })
             {

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -163,6 +163,10 @@ public class Player
             Battlefield.Add(card);
             Debug.Log($"{card.cardName} is entering the battlefield.");
             card.OnEnterPlay(this);
+            if (card is CreatureCard creature)
+            {
+                GameManager.Instance.ShowCreatureEnterVFX(creature);
+            }
             if (card is LandCard)
             {
                 GameManager.Instance.NotifyLandEntered(card, this);


### PR DESCRIPTION
## Summary
- show "onenter" visual effect whenever any creature enters the battlefield
- support both direct player plays and notify-based entries for AI or token spawns

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b2457724832e978582b644331c42