### PR TITLE
Use stack for creature ETB triggers

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -819,15 +819,13 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
                 if (isValid && GameManager.Instance.GetOwnerOfCard(clicked)?.Battlefield.Contains(clicked) == true)
                 {
-                    ability.effect?.Invoke(GameManager.Instance.humanPlayer, clicked);
-                    Debug.Log($"{clicked.cardName} destroyed by optional ETB.");
+                    GameManager.Instance.ResolveOptionalTargeting(clicked);
                 }
                 else
                 {
                     Debug.Log("Clicked invalid target — optional ETB does nothing.");
+                    GameManager.Instance.CancelOptionalTargeting();
                 }
-
-                GameManager.Instance.CancelOptionalTargeting();
                 return;
             }
 

--- a/Assets/Scripts/CreatureCard.cs
+++ b/Assets/Scripts/CreatureCard.cs
@@ -135,6 +135,27 @@ public class CreatureCard : Card
         }
     }
 
+    public override void OnEnterPlay(Player owner)
+    {
+        foreach (var ability in abilities)
+        {
+            if (ability.timing != TriggerTiming.OnEnter)
+                continue;
+
+            if (ability.requiresTarget)
+            {
+                if (owner == GameManager.Instance.humanPlayer)
+                    GameManager.Instance.BeginOptionalTargetSelectionAfterEntry(this, owner, ability);
+                // AI-targeted ETBs handled separately in GameManager
+            }
+            else
+            {
+                GameManager.Instance.StartCoroutine(
+                    GameManager.Instance.ResolveTriggeredAbilityOnStack(ability, owner, this, this));
+            }
+        }
+    }
+
     public override void OnLeavePlay(Player owner)
     {
         base.OnLeavePlay(owner);

--- a/Assets/Scripts/PlayerTargetVisual.cs
+++ b/Assets/Scripts/PlayerTargetVisual.cs
@@ -26,10 +26,7 @@ public class PlayerTargetVisual : MonoBehaviour, IPointerClickHandler
                   GameManager.Instance.optionalAbility.requiredTargetType == SorceryCard.TargetType.CreatureOrPlayer))
         {
             Player target = isHuman ? GameManager.Instance.humanPlayer : GameManager.Instance.aiPlayer;
-            GameManager.Instance.optionalTargetPlayer = target;
-            var ability = GameManager.Instance.optionalAbility;
-            ability.effect?.Invoke(GameManager.Instance.GetOwnerOfCard(GameManager.Instance.targetingCreatureOptional), null);
-            GameManager.Instance.CancelOptionalTargeting();
+            GameManager.Instance.ResolveOptionalPlayerTargeting(target);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Queue creature ETB triggers on the stack instead of resolving immediately
- Add stack visuals and delay before resolving queued triggers
- Route optional ETB targeting through stack resolution for creatures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895bc8aace08327ba7095b45722e1e0