### PR TITLE
Add mythic rarity and update Lich Queen

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2323,7 +2323,7 @@ public static class CardDatabase
                 Add(new CardData //Lich Queen
                     {
                     cardName = "Lich Queen",
-                    rarity = "Rare",
+                    rarity = "Mythic",
                     manaCost = 4,
                     color = new List<string> { "Black", "White" },
                     cardType = CardType.Creature,

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1924,6 +1924,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     case "common": return Color.black;
                     case "uncommon": return Color.gray;
                     case "rare": return new Color(1f, 0.84f, 0f); // gold
+                    case "mythic": return new Color(0.5f, 0f, 0.5f); // purple
                     default: return Color.clear;
                 }
             }

--- a/Assets/Scripts/DeckDatabase.cs
+++ b/Assets/Scripts/DeckDatabase.cs
@@ -210,24 +210,24 @@ public static class DeckDatabase
         }
 
     public static void BuildBossDeck(Player ai)
-        {
-            ai.Deck.Clear();
-            AddCards(ai, "Swamp", 8);
-            AddCards(ai, "Plains", 8);
-            AddCards(ai, "Waterbearer", 3);
-            AddCards(ai, "Ratbat", 3);
-            AddCards(ai, "Death Incarnate", 2);
-            AddCards(ai, "Faith Incarnate", 2);
-            AddCards(ai, "Lights Out", 2);
-            AddCards(ai, "Possessed Innocent", 2);
-            AddCards(ai, "Pure Angel", 1);
-            AddCards(ai, "The Worlds Evil", 1);
-            AddCards(ai, "Massacre", 1);
-            AddCards(ai, "Rotting Dragon", 1);
-            AddCards(ai, "Afterlife Jinx Lantern", 1);
-            AddCards(ai, "Giant Bat", 2);
-            AddCards(ai, "Bog Mosquito", 2);
-            ai.StartingPermanents.Add(CardFactory.Create("Lich Queen"));
+    {
+        ai.Deck.Clear();
+        AddCards(ai, "Swamp", 8);
+        AddCards(ai, "Plains", 8);
+        AddCards(ai, "Waterbearer", 4);
+        AddCards(ai, "Ratbat", 3);
+        AddCards(ai, "Death Incarnate", 2);
+        AddCards(ai, "Faith Incarnate", 2);
+        AddCards(ai, "Lights Out", 2);
+        AddCards(ai, "Possessed Innocent", 2);
+        AddCards(ai, "Pure Angel", 1);
+        AddCards(ai, "The Worlds Evil", 1);
+        AddCards(ai, "Massacre", 1);
+        AddCards(ai, "Afterlife Jinx Lantern", 1);
+        AddCards(ai, "Giant Bat", 2);
+        ai.StartingPermanents.Add(CardFactory.Create("Lich Queen"));
+        ai.StartingPermanents.Add(CardFactory.Create("Dump People"));
+        ai.StartingPermanents.Add(CardFactory.Create("Dump People"));
         }
 
     public static void BuildRuinsDeck(Player ai)


### PR DESCRIPTION
## Summary
- add support for purple-colored mythic rarity symbol
- convert Lich Queen card to mythic rarity

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897a9918edc83279898d144eb455f7e