### PR TITLE
Trigger upkeep abilities on stack

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -290,32 +290,7 @@ public class TurnSystem : MonoBehaviour
                         ? GameManager.Instance.humanPlayer
                         : GameManager.Instance.aiPlayer;
 
-                    foreach (var card in player.Battlefield.ToList())
-                    {
-                        foreach (var ability in card.abilities)
-                        {
-                            if (ability.timing == TriggerTiming.OnUpkeep && ability.effect != null)
-                            {
-                                Debug.Log($"[Upkeep Trigger] {card.cardName} triggers OnUpkeep.");
-
-                                int oldLife = player.Life;
-                                ability.effect.Invoke(player, card);
-                                int gained = player.Life - oldLife;
-
-                                if (gained > 0)
-                                {
-                                    GameManager.Instance.ShowFloatingHeal(
-                                        gained,
-                                        player == GameManager.Instance.humanPlayer
-                                            ? GameManager.Instance.playerLifeContainer
-                                            : GameManager.Instance.enemyLifeContainer
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    AdvancePhase();
+                    StartCoroutine(HandleUpkeepTriggers(player));
                     break;
 
                 case TurnPhase.Draw:
@@ -1183,6 +1158,24 @@ public class TurnSystem : MonoBehaviour
                     }
                     break;
             }
+        }
+
+        private IEnumerator HandleUpkeepTriggers(Player player)
+        {
+            foreach (var card in player.Battlefield.ToList())
+            {
+                foreach (var ability in card.abilities)
+                {
+                    if (ability.timing == TriggerTiming.OnUpkeep && ability.effect != null)
+                    {
+                        Debug.Log($"[Upkeep Trigger] {card.cardName} triggers OnUpkeep.");
+                        GameManager.Instance.pendingStackEffects++;
+                        yield return StartCoroutine(GameManager.Instance.ResolveTriggeredAbilityOnStack(ability, player, card, card));
+                    }
+                }
+            }
+
+            AdvancePhase();
         }
 
         private IEnumerator WaitAndAdvancePhase()


### PR DESCRIPTION
## Summary
- Queue "at the beginning of upkeep" abilities onto the stack, processing them sequentially like ETB triggers.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689853a4aa708327b42b54068c6e3950