### PR TITLE
Show card preview for collection entries

### DIFF
--- a/Assets/Scripts/DeckEditorCollectionButton.cs
+++ b/Assets/Scripts/DeckEditorCollectionButton.cs
@@ -1,7 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
-public class DeckEditorCollectionButton : MonoBehaviour
+public class DeckEditorCollectionButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 {
     public CardData Data { get; private set; }
     private DeckEditorManager manager;
@@ -21,5 +22,21 @@ public class DeckEditorCollectionButton : MonoBehaviour
     private void OnClick()
     {
         manager?.OnCollectionEntryClicked(Data, gameObject);
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        if (Data == null || CardHoverPreview.Instance == null)
+            return;
+
+        Card card = CardFactory.Create(Data.cardName);
+        if (card != null)
+            CardHoverPreview.Instance.ShowCard(card);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        if (CardHoverPreview.Instance != null)
+            CardHoverPreview.Instance.HidePreview();
     }
 }


### PR DESCRIPTION
## Summary
- preview card data when hovering over non-deck cards in deck manager

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68985f4fa69c8327abcd76f9eb9c5a65