### PR TITLE
Fix lifelink damage calculation when blocked

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -749,15 +749,22 @@ public class GameManager : MonoBehaviour
                 int remainingDamage = attackerDamage;
                 int totalDamageFromBlockers = 0;
 
-                foreach (var blocker in blockers)
+                bool attackerHasTrample = attacker.keywordAbilities.Contains(KeywordAbility.Trample);
+                for (int i = 0; i < blockers.Count; i++)
                 {
+                    var blocker = blockers[i];
                     bool attackerProtected = blocker.color.Any(c => attacker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
                     bool blockerProtected = attacker.color.Any(c => blocker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
 
                     int damageToBlocker = 0;
                     if (!blockerProtected)
                     {
-                        damageToBlocker = Mathf.Min(remainingDamage, blocker.toughness);
+                        bool isLastBlocker = i == blockers.Count - 1;
+                        if (!attackerHasTrample && isLastBlocker)
+                            damageToBlocker = remainingDamage;
+                        else
+                            damageToBlocker = Mathf.Min(remainingDamage, blocker.toughness);
+
                         blocker.TakeDamage(damageToBlocker);
                         if (attacker.keywordAbilities.Contains(KeywordAbility.Deathtouch) && damageToBlocker > 0)
                             blocker.Kill();
@@ -3215,15 +3222,22 @@ public class GameManager : MonoBehaviour
                     int remainingDamage = attackerDamage;
                     int totalDamageFromBlockers = 0;
 
-                    foreach (var blocker in blockers)
+                    bool attackerHasTrample = attacker.keywordAbilities.Contains(KeywordAbility.Trample);
+                    for (int i = 0; i < blockers.Count; i++)
                     {
+                        var blocker = blockers[i];
                         bool attackerProtected = blocker.color.Any(c => attacker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
                         bool blockerProtected = attacker.color.Any(c => blocker.keywordAbilities.Contains(ProtectionUtils.GetProtectionKeyword(c)));
 
                         int damageToBlocker = 0;
                         if (!blockerProtected)
                         {
-                            damageToBlocker = Mathf.Min(remainingDamage, blocker.toughness);
+                            bool isLastBlocker = i == blockers.Count - 1;
+                            if (!attackerHasTrample && isLastBlocker)
+                                damageToBlocker = remainingDamage;
+                            else
+                                damageToBlocker = Mathf.Min(remainingDamage, blocker.toughness);
+
                             blocker.TakeDamage(damageToBlocker);
                             if (attacker.keywordAbilities.Contains(KeywordAbility.Deathtouch) && damageToBlocker > 0)
                                 blocker.Kill();

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1376,12 +1376,19 @@ public class TurnSystem : MonoBehaviour
                 int remainingDamage = attacker.power;
                 int casualties = 0;
                 int valueLost = 0;
-                foreach (var b in blockers.OrderBy(x => x.toughness))
+                var orderedBlockers = blockers.OrderBy(x => x.toughness).ToList();
+                bool attackerHasTrample = attacker.keywordAbilities.Contains(KeywordAbility.Trample);
+                for (int i = 0; i < orderedBlockers.Count && remainingDamage > 0; i++)
                 {
-                    if (remainingDamage <= 0)
-                        break;
+                    var b = orderedBlockers[i];
 
-                    int damage = Mathf.Min(remainingDamage, b.toughness);
+                    int damage;
+                    bool isLastBlocker = i == orderedBlockers.Count - 1;
+                    if (!attackerHasTrample && isLastBlocker)
+                        damage = remainingDamage;
+                    else
+                        damage = Mathf.Min(remainingDamage, b.toughness);
+
                     if (attackerHasDeathtouch && remainingDamage > 0)
                         damage = b.toughness;
 


### PR DESCRIPTION
## Summary
- Ensure blockers without trample receive an attacker's full remaining power so life gain and damage reflect the creature's actual strength
- Align AI's blocker evaluation with the new full-damage rule

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a38f3cfd48327b12dd9b4c84e2f27