### PR TITLE
Honor indestructible for destroy effects

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -80,7 +80,8 @@ public static class CardDatabase
                                 effect = (Player owner, Card target) =>
                                 {
                                     Player controller = GameManager.Instance.GetOwnerOfCard(target);
-                                    GameManager.Instance.SendToGraveyard(target, controller);
+                                    if (!target.keywordAbilities.Contains(KeywordAbility.Indestructible))
+                                        GameManager.Instance.SendToGraveyard(target, controller);
                                 }
                             }
                         }
@@ -720,7 +721,8 @@ public static class CardDatabase
                             excludeArtifactCreatures = true,
                             effect = (Player owner, Card target) =>
                             {
-                                if (target is CreatureCard creature && !creature.color.Contains("Artifact"))
+                                if (target is CreatureCard creature && !creature.color.Contains("Artifact")
+                                    && !target.keywordAbilities.Contains(KeywordAbility.Indestructible))
                                 {
                                     Player controller = GameManager.Instance.GetOwnerOfCard(target);
                                     GameManager.Instance.SendToGraveyard(target, controller);
@@ -1815,7 +1817,8 @@ public static class CardDatabase
                             effect = (Player owner, Card target) =>
                             {
                                 Player controller = GameManager.Instance.GetOwnerOfCard(target);
-                                GameManager.Instance.SendToGraveyard(target, controller);
+                                if (!target.keywordAbilities.Contains(KeywordAbility.Indestructible))
+                                    GameManager.Instance.SendToGraveyard(target, controller);
                             }
                         }
                     }

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -212,6 +212,9 @@ public class SorceryCard : Card
                         var targets = player.Battlefield
                             .Where(card =>
                             {
+                                if (card.keywordAbilities.Contains(KeywordAbility.Indestructible))
+                                    return false;
+
                                 if (typeOfPermanentToDestroyAll == PermanentTypeToDestroy.Land && card is LandCard)
                                     return true;
 
@@ -374,7 +377,9 @@ public class SorceryCard : Card
                     List<(Card card, Player owner)> toDestroy = new List<(Card, Player)>();
                     foreach (var player in new[] { GameManager.Instance.humanPlayer, GameManager.Instance.aiPlayer })
                     {
-                        foreach (var card in player.Battlefield.OfType<CreatureCard>().Where(c => c.cardName == name).ToList())
+                        foreach (var card in player.Battlefield.OfType<CreatureCard>()
+                            .Where(c => c.cardName == name && !c.keywordAbilities.Contains(KeywordAbility.Indestructible))
+                            .ToList())
                         {
                             toDestroy.Add((card, player));
                         }
@@ -409,8 +414,15 @@ public class SorceryCard : Card
 
                     if (typeMatches && colorMatches)
                     {
-                        GameManager.Instance.SendToGraveyard(target, GameManager.Instance.GetOwnerOfCard(target));
-                        Debug.Log($"{cardName} destroyed {target.cardName}.");
+                        if (target.keywordAbilities.Contains(KeywordAbility.Indestructible))
+                        {
+                            Debug.Log($"{cardName} failed to destroy {target.cardName}: indestructible.");
+                        }
+                        else
+                        {
+                            GameManager.Instance.SendToGraveyard(target, GameManager.Instance.GetOwnerOfCard(target));
+                            Debug.Log($"{cardName} destroyed {target.cardName}.");
+                        }
 
                         ResolveEffect(caster);
                         return;


### PR DESCRIPTION
## Summary
- Prevent mass-destroy spells from affecting indestructible permanents
- Skip indestructible creatures when destroying by name or type
- Guard card abilities that destroy permanents against indestructible targets

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a428f312083278a544e6f2b54ecfb