### PR TITLE
Guard alpha hit testing for unreadable textures

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -97,8 +97,18 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 artImage = GetComponentInChildren<Image>(true);
         }
 
-        if (artImage != null)
-            artImage.alphaHitTestMinimumThreshold = 0.1f;
+        if (artImage != null && artImage.sprite != null)
+        {
+            var tex = artImage.sprite.texture;
+            if (tex != null && tex.isReadable)
+            {
+                artImage.alphaHitTestMinimumThreshold = 0.1f;
+            }
+            else
+            {
+                Debug.LogWarning($"Texture for {artImage.name} is not readable; alpha hit testing disabled.");
+            }
+        }
 
         DisableRaycast(cardRarity);
         DisableRaycast(coloredManaIcon1);

--- a/Assets/Scripts/ColorButtonBehavior.cs
+++ b/Assets/Scripts/ColorButtonBehavior.cs
@@ -56,9 +56,17 @@ public class ColorButtonBehavior : MonoBehaviour, IPointerEnterHandler, IPointer
     void Start()
         {
             Image img = GetComponent<Image>();
-            if (img != null)
+            if (img != null && img.sprite != null)
             {
-                img.alphaHitTestMinimumThreshold = 0.1f;
+                var tex = img.sprite.texture;
+                if (tex != null && tex.isReadable)
+                {
+                    img.alphaHitTestMinimumThreshold = 0.1f;
+                }
+                else
+                {
+                    Debug.LogWarning($"Texture for {img.name} is not readable; alpha hit testing disabled.");
+                }
             }
 
             if (hoverGlow != null)


### PR DESCRIPTION
## Summary
- Avoid setting alphaHitTestMinimumThreshold on card art and color buttons when the texture isn't readable
- Log warnings when alpha-based hit testing is skipped due to unreadable textures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b452c1760832795efc550422257c7