### PR TITLE
Add Wall of Putrid Flesh card with graveyard recursion

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -197,6 +197,9 @@ public class Card
                                 case ActivatedAbility.ReturnSelfFromGraveyard:
                                     lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to the battlefield tapped.");
                                     break;
+                                case ActivatedAbility.ReturnSelfFromGraveyardToHand:
+                                    lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to your hand.");
+                                    break;
                             }
                         }
                     }

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -883,6 +883,27 @@ public static class CardDatabase
                     keywordAbilities = new List<KeywordAbility> { },
                     artwork = Resources.Load<Sprite>("Art/stubborn_skeleton")
                     });
+                Add(new CardData //Wall of Putrid Flesh
+                    {
+                    cardName = "Wall of Putrid Flesh",
+                    rarity = "Common",
+                    manaCost = 1,
+                    color = new List<string> { "Black" },
+                    cardType = CardType.Creature,
+                    power = 0,
+                    toughness = 1,
+                    subtypes = new List<string> { "Zombie", "Wall" },
+                    keywordAbilities = new List<KeywordAbility>
+                    {
+                        KeywordAbility.Defender
+                    },
+                    manaToPayToActivate = 1,
+                    activatedAbilities = new List<ActivatedAbility>
+                    {
+                        ActivatedAbility.ReturnSelfFromGraveyardToHand
+                    },
+                    artwork = Resources.Load<Sprite>("Art/wall_of_putrid_flesh")
+                    });
                 Add(new CardData //Famished crow
                     {
                     cardName = "Famished Crow",

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -861,19 +861,33 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             {
                 if (isInGraveyardViewer && linkedCard is CreatureCard graveCreature &&
                     GameManager.Instance.humanPlayer.Graveyard.Contains(linkedCard) &&
-                    graveCreature.activatedAbilities != null &&
-                    graveCreature.activatedAbilities.Contains(ActivatedAbility.ReturnSelfFromGraveyard))
+                    graveCreature.activatedAbilities != null)
                 {
                     Player player = GameManager.Instance.humanPlayer;
                     int cost = graveCreature.manaToPayToActivate;
-                    if (player.ColoredMana.Total() >= cost)
+                    if (graveCreature.activatedAbilities.Contains(ActivatedAbility.ReturnSelfFromGraveyard))
                     {
-                        player.ColoredMana.SpendGeneric(cost);
-                        GameManager.Instance.ReturnCreatureFromGraveyardToBattlefield(player, graveCreature);
+                        if (player.ColoredMana.Total() >= cost)
+                        {
+                            player.ColoredMana.SpendGeneric(cost);
+                            GameManager.Instance.ReturnCreatureFromGraveyardToBattlefield(player, graveCreature);
+                        }
+                        else
+                        {
+                            Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                        }
                     }
-                    else
+                    else if (graveCreature.activatedAbilities.Contains(ActivatedAbility.ReturnSelfFromGraveyardToHand))
                     {
-                        Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                        if (player.ColoredMana.Total() >= cost)
+                        {
+                            player.ColoredMana.SpendGeneric(cost);
+                            GameManager.Instance.ReturnCreatureFromGraveyardToHand(player, graveCreature);
+                        }
+                        else
+                        {
+                            Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                        }
                     }
                 }
                 return;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1721,6 +1721,29 @@ public class GameManager : MonoBehaviour
         UpdateUI();
     }
 
+    public void ReturnCreatureFromGraveyardToHand(Player player, CreatureCard creature)
+    {
+        if (creature == null || !player.Graveyard.Contains(creature))
+            return;
+
+        player.Graveyard.Remove(creature);
+        player.Hand.Add(creature);
+
+        if (player == humanPlayer)
+        {
+            GameObject obj = Instantiate(cardPrefab, playerHandArea);
+            CardVisual visual = obj.GetComponent<CardVisual>();
+            CardData data = CardDatabase.GetCardData(creature.cardName);
+            visual.Setup(creature, this, data);
+            activeCardVisuals.Add(visual);
+        }
+
+        RefreshGraveyardVisuals(player);
+        if (graveyardViewActive && graveyardUIManager != null)
+            graveyardUIManager.Open(player.Graveyard);
+        UpdateUI();
+    }
+
     public void TapCardForMana(CreatureCard creature)
     {
         if (!creature.isTapped)

--- a/Assets/Scripts/KeywordAbility.cs
+++ b/Assets/Scripts/KeywordAbility.cs
@@ -51,4 +51,5 @@ public enum ActivatedAbility
     PayToBuffSelf,
     Equip,
     ReturnSelfFromGraveyard,
+    ReturnSelfFromGraveyardToHand,
 }


### PR DESCRIPTION
## Summary
- add common black creature Wall of Putrid Flesh with graveyard recursion
- support new activated ability to return cards from graveyard to hand
- wire ability into card text, visual interaction, and game manager

## Testing
- `dotnet test` *(fails: command not found)*
- `mcs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b48cef81083279c9d92a882f99bbb