### PR TITLE
Allow The Worlds Evil to return from graveyard

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -1263,6 +1263,11 @@ public static class CardDatabase
                         power = 8,
                         toughness = 8,
                         subtypes = new List<string> { "Demon" },
+                        manaToPayToActivate = 8,
+                        activatedAbilities = new List<ActivatedAbility>
+                        {
+                            ActivatedAbility.ReturnSelfFromGraveyard
+                        },
                         keywordAbilities = new List<KeywordAbility>
                         {
                             KeywordAbility.Flying,


### PR DESCRIPTION
## Summary
- Let The Worlds Evil pay 8 mana to return from the graveyard tapped
- Keep existing enter-the-battlefield trigger intact so it fires on return

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4cf0b078832795a164dea30df850