### PR TITLE
Add Bell Call sorcery and library reveal mechanic

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -67,6 +67,7 @@ public class CardData
     public bool eachPlayerGainLifeEqualToLands;
     public bool exileAllCreaturesFromGraveyards = false;
     public bool swapGraveyardAndLibrary = false;
+    public bool revealUntilCreature = false;
     public bool returnRandomCreatureFromGraveyard = false;
     public bool returnRandomCheapCreatureToBattlefield = false;
     public int maxManaCostForReturn = 0;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2454,6 +2454,16 @@ public static class CardDatabase
                         artwork = Resources.Load<Sprite>("Art/deny_the_afterlife"),
                         exileAllCreaturesFromGraveyards = true
                     });
+                Add(new CardData { //Bell Call
+                    cardName = "Bell Call",
+                    rarity = "Common",
+                    cardType = CardType.Sorcery,
+                    manaCost = 2,
+                    color = new List<string> { "White" },
+                    revealUntilCreature = true,
+                    artwork = Resources.Load<Sprite>("Art/bell_call"),
+                    abilities = new List<CardAbility>(),
+                    });
             //BLUE
                 Add(new CardData { //Blast of knowledge
                     cardName = "Blast of Knowledge",

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -56,6 +56,7 @@ public static class CardFactory
                 sorcery.manaToGainMin = data.manaToGainMin;
                 sorcery.manaToGainMax = data.manaToGainMax;
                 sorcery.swapGraveyardAndLibrary = data.swapGraveyardAndLibrary;
+                sorcery.revealUntilCreature = data.revealUntilCreature;
                 sorcery.returnRandomCreatureFromGraveyard = data.returnRandomCreatureFromGraveyard;
                 sorcery.returnRandomCheapCreatureToBattlefield = data.returnRandomCheapCreatureToBattlefield;
                 sorcery.maxManaCostForReturn = data.maxManaCostForReturn;

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -2113,6 +2113,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 rules += $"Deal {sorcery.damageToEachCreatureAndPlayer} damage to each creature and each player.\n";
             if (sorcery.swapGraveyardAndLibrary)
                 rules += "Each player exchanges their graveyard with their library, then shuffles their deck.\n";
+            if (sorcery.revealUntilCreature)
+                rules += "Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand, then shuffle.\n";
             if (sorcery.destroyTargetIfTypeMatches)
             {
                 string destroyType = sorcery.requiredTargetType switch

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1568,6 +1568,77 @@ public class GameManager : MonoBehaviour
         UpdateUI();
     }
 
+    public IEnumerator RevealUntilCreature(Player player)
+    {
+        List<Card> revealedNonCreatures = new List<Card>();
+        List<CardVisual> visuals = new List<CardVisual>();
+        Card creatureCard = null;
+        CardVisual creatureVisual = null;
+
+        int index = 0;
+        float spacing = 150f;
+
+        while (player.Deck.Count > 0)
+        {
+            Card top = player.Deck[0];
+            player.Deck.RemoveAt(0);
+
+            GameObject obj = Instantiate(cardPrefab, stackZone);
+            obj.transform.localPosition = new Vector3(index * spacing, 0f, 0f);
+            CardVisual visual = obj.GetComponent<CardVisual>();
+            CardData data = CardDatabase.GetCardData(top.cardName);
+            visual.Setup(top, this, data);
+            visual.isInStack = true;
+            visuals.Add(visual);
+
+            if (top is CreatureCard)
+            {
+                creatureCard = top;
+                creatureVisual = visual;
+                break;
+            }
+            else
+            {
+                revealedNonCreatures.Add(top);
+            }
+
+            index++;
+            yield return new WaitForSeconds(0.5f);
+        }
+
+        yield return new WaitForSeconds(0.5f);
+
+        if (creatureCard != null)
+        {
+            player.Hand.Add(creatureCard);
+            if (player == humanPlayer)
+            {
+                creatureVisual.transform.SetParent(playerHandArea, false);
+                creatureVisual.isInStack = false;
+                activeCardVisuals.Add(creatureVisual);
+            }
+            else
+            {
+                Destroy(creatureVisual.gameObject);
+                if (enemyHandText != null)
+                    enemyHandText.text = "Hand: " + player.Hand.Count;
+            }
+        }
+
+        foreach (var card in revealedNonCreatures)
+            player.Deck.Add(card);
+
+        foreach (var visual in visuals)
+        {
+            if (!(visual.linkedCard is CreatureCard))
+                Destroy(visual.gameObject);
+        }
+
+        ShuffleDeck(player);
+        UpdateUI();
+        pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
+    }
+
     public void ReturnRandomInstantOrSorceryFromGraveyard(Player player)
     {
         var spells = player.Graveyard

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -17,6 +17,7 @@ public class SorceryCard : Card
     public bool eachPlayerGainLifeEqualToLands = false;
     public bool exileAllCreaturesFromGraveyards = false;
     public bool swapGraveyardAndLibrary = false;
+    public bool revealUntilCreature = false;
     public bool returnRandomCreatureFromGraveyard = false;
     public bool returnRandomCheapCreatureToBattlefield = false;
     public int maxManaCostForReturn = 0;
@@ -65,6 +66,13 @@ public class SorceryCard : Card
     public virtual void ResolveEffect(Player caster)
         {
             bool didSomething = false;
+
+            if (revealUntilCreature)
+            {
+                GameManager.Instance.pendingStackEffects++;
+                GameManager.Instance.StartCoroutine(GameManager.Instance.RevealUntilCreature(caster));
+                didSomething = true;
+            }
 
             if (!string.IsNullOrEmpty(tokenToCreate) && numberOfTokensMax > 0)
             {


### PR DESCRIPTION
## Summary
- Add Bell Call, a white common sorcery that reveals cards until a creature is found and shuffles the rest
- Introduce revealUntilCreature field and coroutine-based effect to show revealed cards and move the creature to hand
- Display rules text for the new effect

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b525c6a548327a4caad9631f16321