### PR TITLE
Show VFX for triggered stack entries

### DIFF
--- a/Assets/Prefab/TriggerPrefab.prefab
+++ b/Assets/Prefab/TriggerPrefab.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 200}
+  m_SizeDelta: {x: 80, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6166682046163185921
 CanvasRenderer:

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -6164,6 +6164,7 @@ MonoBehaviour:
   enemyLifeContainer: {fileID: 219930519}
   floatingDamagePrefab: {fileID: 6263719099324857846, guid: dbcb8822c50f8d6418d4bbed97b45924, type: 3}
   favouritePopupPrefab: {fileID: 8843468045292096794, guid: 2a04a38c796e1d746aae986d01f35727, type: 3}
+  triggerVFXPrefab: {fileID: 6166682046645345468, guid: 30452ca31a8ab3e4bacd17dd8910acbf, type: 3}
   blueIcon: {fileID: 21300000, guid: cf5da0752d7da9f4db791fed64ba1347, type: 3}
   whiteIcon: {fileID: 21300000, guid: e51d0f0e20f24834f893872fd6719259, type: 3}
   blackIcon: {fileID: 21300000, guid: 45c943c1120a5e74dbfdc1bf4d6a0e44, type: 3}

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -49,6 +49,7 @@ public class GameManager : MonoBehaviour
     public GameObject enemyLifeContainer;
     public GameObject floatingDamagePrefab;
     public GameObject favouritePopupPrefab;
+    public GameObject triggerVFXPrefab;
 
     // Tracks cumulative life changes during a combat step
     private TMP_Text playerLifeDeltaText;
@@ -1268,6 +1269,15 @@ public class GameManager : MonoBehaviour
             stackVisual.transform.localRotation = Quaternion.identity;
             stackVisual.transform.localScale = Vector3.one;
 
+            GameObject triggerVFX = null;
+            if (triggerVFXPrefab != null)
+            {
+                triggerVFX = Instantiate(triggerVFXPrefab, stackObj.transform);
+                RectTransform rt = triggerVFX.GetComponent<RectTransform>();
+                if (rt != null)
+                    rt.anchoredPosition = Vector2.zero;
+            }
+
             yield return new WaitForSeconds(2f);
 
             int oldLife = owner.Life;
@@ -1283,6 +1293,8 @@ public class GameManager : MonoBehaviour
             UpdateUI();
             optionalTargetPlayer = null;
 
+            if (triggerVFX != null)
+                Destroy(triggerVFX);
             Destroy(stackObj);
             isStackBusy = false;
             CheckForGameEnd();


### PR DESCRIPTION
## Summary
- add triggerVFXPrefab hook in GameManager
- spawn and remove trigger VFX around triggered stack cards

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc88f76b483278c3412fe95723ae6