### PR TITLE
Queue death triggers on stack

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -93,27 +93,17 @@ public class Card
         }
 
     public virtual void OnLeavePlay(Player owner)
+    {
+        foreach (var ability in abilities)
         {
-            foreach (var ability in abilities)
-            {
-                if (ability.timing == TriggerTiming.OnDeath && ability.effect != null)
-                {
-                    int oldLife = owner.Life;
-                    ability.effect.Invoke(owner, this);
-                    int gained = owner.Life - oldLife;
+            if (ability.timing != TriggerTiming.OnDeath || ability.effect == null)
+                continue;
 
-                    if (gained > 0)
-                    {
-                        GameManager.Instance.ShowFloatingHeal(
-                            gained,
-                            owner == GameManager.Instance.humanPlayer
-                                ? GameManager.Instance.playerLifeContainer
-                                : GameManager.Instance.enemyLifeContainer
-                        );
-                    }
-                }
-            }
+            GameManager.Instance.pendingStackEffects++;
+            GameManager.Instance.StartCoroutine(
+                GameManager.Instance.ResolveTriggeredAbilityOnStack(ability, owner, this, this));
         }
+    }
 
     public virtual string GetCardText()
         {

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1072,14 +1072,16 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
             TurnSystem.TurnPhase phase = TurnSystem.Instance.currentPhase;
             bool canActivateArtifact =
-                (TurnSystem.Instance.currentPlayer == TurnSystem.PlayerType.Human &&
-                    (phase == TurnSystem.TurnPhase.Main1 ||
-                     phase == TurnSystem.TurnPhase.Main2 ||
-                     phase == TurnSystem.TurnPhase.ConfirmAttackers ||
-                     phase == TurnSystem.TurnPhase.ConfirmBlockers)) ||
-                (TurnSystem.Instance.currentPlayer == TurnSystem.PlayerType.AI &&
-                    (phase == TurnSystem.TurnPhase.ChooseBlockers ||
-                     phase == TurnSystem.TurnPhase.ConfirmBlockers));
+                (
+                    (TurnSystem.Instance.currentPlayer == TurnSystem.PlayerType.Human &&
+                        (phase == TurnSystem.TurnPhase.Main1 ||
+                         phase == TurnSystem.TurnPhase.Main2 ||
+                         phase == TurnSystem.TurnPhase.ConfirmAttackers ||
+                         phase == TurnSystem.TurnPhase.ConfirmBlockers)) ||
+                    (TurnSystem.Instance.currentPlayer == TurnSystem.PlayerType.AI &&
+                        (phase == TurnSystem.TurnPhase.ChooseBlockers ||
+                         phase == TurnSystem.TurnPhase.ConfirmBlockers))
+                ) && !GameManager.Instance.IsStackActive();
 
             if (linkedCard.activatedAbilities != null &&
             linkedCard.activatedAbilities.Contains(ActivatedAbility.TapForMana) &&
@@ -1298,18 +1300,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 canActivateArtifact)
             {
                 linkedCard.isTapped = true;
-
-                GameManager.Instance.humanPlayer.Life -= linkedCard.plagueAmount;
-                GameManager.Instance.aiPlayer.Life -= linkedCard.plagueAmount;
-
-                GameManager.Instance.ShowFloatingDamage(linkedCard.plagueAmount, GameManager.Instance.playerLifeContainer);
-                GameManager.Instance.ShowFloatingDamage(linkedCard.plagueAmount, GameManager.Instance.enemyLifeContainer);
-
-                GameManager.Instance.UpdateUI();
-                SoundManager.Instance.PlaySound(SoundManager.Instance.plague);
-                GameManager.Instance.ShowBloodSplatVFX(linkedCard);
+                GameManager.Instance.QueueArtifactActivatedAbility(linkedCard as ArtifactCard, ActivatedAbility.TapToPlague, GameManager.Instance.humanPlayer);
                 UpdateVisual();
-                GameManager.Instance.CheckForGameEnd();
+                GameManager.Instance.UpdateUI();
                 return;
             }
             
@@ -1385,8 +1378,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     canActivateArtifact)
                 {
                     linkedCard.isTapped = true;
-                    GameManager.Instance.TryGainLife(GameManager.Instance.humanPlayer, 1);
+                    GameManager.Instance.QueueArtifactActivatedAbility(linkedCard as ArtifactCard, ActivatedAbility.TapToGainLife, GameManager.Instance.humanPlayer);
                     UpdateVisual();
+                    GameManager.Instance.UpdateUI();
                     return;
                 }
 
@@ -1403,12 +1397,25 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
                     if (player.ColoredMana.Total() >= remaining)
                     {
-                        // ... [mana payment code]
-                        GameManager.Instance.TryGainLife(player, artifact.lifeToGain);
+                        int useColorless = Mathf.Min(player.ColoredMana.Colorless, remaining);
+                        player.ColoredMana.Colorless -= useColorless;
+                        remaining -= useColorless;
+
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.White, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Blue, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Black, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Red, remaining);
+                        remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Green, remaining);
+
+                        if (remaining > 0)
+                        {
+                            Debug.Log("Not enough mana for ability.");
+                            return;
+                        }
+
                         linkedCard.isTapped = true;
-                        SoundManager.Instance.PlaySound(SoundManager.Instance.drink);
-                        SoundManager.Instance.PlaySound(SoundManager.Instance.gain_life);
                         GameManager.Instance.SendToGraveyard(linkedCard, player);
+                        GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.SacrificeForLife, player);
                         GameManager.Instance.UpdateUI();
                         UpdateVisual();
 
@@ -1526,12 +1533,9 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                             Debug.LogWarning("Draw ability: Not enough mana even though initial check passed.");
                             return;
                         }
-
-                        GameManager.Instance.DrawCards(player, artifact.cardsToDraw);
-
-                        SoundManager.Instance.PlaySound(SoundManager.Instance.drink);
                         linkedCard.isTapped = true;
                         GameManager.Instance.SendToGraveyard(linkedCard, player);
+                        GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.SacrificeToDrawCards, player);
                         GameManager.Instance.UpdateUI();
                         UpdateVisual();
                         Debug.Log($"{linkedCard.cardName} activated: Draw {artifact.cardsToDraw} cards.");
@@ -1574,9 +1578,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                             Debug.Log("Not enough mana for ability.");
                             return;
                         }
-
                         linkedCard.isTapped = true;
-                        GameManager.Instance.SearchLibraryForRandomPotionToBattlefield(player);
+                        GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.TapToPlayRandomPotion, player);
                         GameManager.Instance.UpdateUI();
                         UpdateVisual();
                     }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1253,59 +1253,71 @@ public class GameManager : MonoBehaviour
             }
         }
 
-    public IEnumerator ResolveTriggeredAbilityOnStack(CardAbility ability, Player owner, Card source, Card target)
+    public IEnumerator ResolveTriggeredAbilityOnStack(
+        CardAbility ability,
+        Player owner,
+        Card source,
+        Card target,
+        Card deadCreature = null)
+    {
+        yield return new WaitUntil(() => !isStackBusy);
+        pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
+        isStackBusy = true;
+        TurnSystem.Instance.lastPhaseBeforeStack = TurnSystem.Instance.currentPhase;
+
+        GameObject stackObj = Instantiate(cardPrefab, stackZone);
+        CardVisual stackVisual = stackObj.GetComponent<CardVisual>();
+        stackVisual.Setup(source, this);
+        stackVisual.isInStack = true;
+        stackVisual.UpdateVisual();
+        stackVisual.transform.localPosition = Vector3.zero;
+        stackVisual.transform.localRotation = Quaternion.identity;
+        stackVisual.transform.localScale = Vector3.one;
+
+        GameObject triggerVFX = null;
+        if (triggerVFXPrefab != null)
         {
-            yield return new WaitUntil(() => !isStackBusy);
-            pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
-            isStackBusy = true;
-            TurnSystem.Instance.lastPhaseBeforeStack = TurnSystem.Instance.currentPhase;
-
-            GameObject stackObj = Instantiate(cardPrefab, stackZone);
-            CardVisual stackVisual = stackObj.GetComponent<CardVisual>();
-            stackVisual.Setup(source, this);
-            stackVisual.isInStack = true;
-            stackVisual.UpdateVisual();
-            stackVisual.transform.localPosition = Vector3.zero;
-            stackVisual.transform.localRotation = Quaternion.identity;
-            stackVisual.transform.localScale = Vector3.one;
-
-            GameObject triggerVFX = null;
-            if (triggerVFXPrefab != null)
-            {
-                triggerVFX = Instantiate(triggerVFXPrefab, stackObj.transform);
-                RectTransform rt = triggerVFX.GetComponent<RectTransform>();
-                if (rt != null)
-                    rt.anchoredPosition = Vector2.zero;
-            }
-
-            yield return new WaitForSeconds(2f);
-
-            int oldLife = owner.Life;
-            ability.effect?.Invoke(owner, target);
-            int gained = owner.Life - oldLife;
-            if (gained > 0)
-            {
-                ShowFloatingHeal(gained, owner == humanPlayer ? playerLifeContainer : enemyLifeContainer);
-            }
-
-            CheckDeaths(humanPlayer);
-            CheckDeaths(aiPlayer);
-            UpdateUI();
-            optionalTargetPlayer = null;
-
-            if (triggerVFX != null)
-                Destroy(triggerVFX);
-            Destroy(stackObj);
-            isStackBusy = false;
-            CheckForGameEnd();
-
-            if (owner == aiPlayer && TurnSystem.Instance.waitingToResumeAI && pendingStackEffects == 0)
-            {
-                Debug.Log("Resuming AI phase after stack.");
-                TurnSystem.Instance.waitingToResumeAI = false;
-                TurnSystem.Instance.RunSpecificPhase(TurnSystem.Instance.lastPhaseBeforeStack);
-            }
+            triggerVFX = Instantiate(triggerVFXPrefab, stackObj.transform);
+            RectTransform rt = triggerVFX.GetComponent<RectTransform>();
+            if (rt != null)
+                rt.anchoredPosition = Vector2.zero;
         }
+
+        yield return new WaitForSeconds(2f);
+
+        Card previousDead = lastDeadCreature;
+        if (deadCreature != null)
+            lastDeadCreature = deadCreature;
+
+        int oldLife = owner.Life;
+        ability.effect?.Invoke(owner, target);
+        int gained = owner.Life - oldLife;
+        if (gained > 0)
+        {
+            ShowFloatingHeal(gained, owner == humanPlayer ? playerLifeContainer : enemyLifeContainer);
+        }
+
+        if (deadCreature != null)
+            lastDeadCreature = previousDead;
+
+        CheckDeaths(humanPlayer);
+        CheckDeaths(aiPlayer);
+        UpdateUI();
+        optionalTargetPlayer = null;
+
+        if (triggerVFX != null)
+            Destroy(triggerVFX);
+        Destroy(stackObj);
+        isStackBusy = false;
+        CheckForGameEnd();
+
+        if (owner == aiPlayer && TurnSystem.Instance.waitingToResumeAI && pendingStackEffects == 0)
+        {
+            Debug.Log("Resuming AI phase after stack.");
+            TurnSystem.Instance.waitingToResumeAI = false;
+            TurnSystem.Instance.RunSpecificPhase(TurnSystem.Instance.lastPhaseBeforeStack);
+        }
+    }
 
     public void QueueArtifactActivatedAbility(ArtifactCard artifact, ActivatedAbility ability, Player controller, Card target = null)
     {
@@ -3986,7 +3998,8 @@ public class GameManager : MonoBehaviour
                     {
                         if (ability.timing == TriggerTiming.OnCreatureDiesOrDiscarded && ability.effect != null)
                         {
-                            ability.effect.Invoke(player, card);
+                            pendingStackEffects++;
+                            StartCoroutine(ResolveTriggeredAbilityOnStack(ability, player, card, card, creature));
                         }
                     }
                 }
@@ -3998,8 +4011,6 @@ public class GameManager : MonoBehaviour
             if (!(creature is CreatureCard))
                 return;
 
-            lastDeadCreature = creature;
-
             foreach (var player in new[] { humanPlayer, aiPlayer })
             {
                 foreach (var card in player.Battlefield.ToList())
@@ -4008,13 +4019,12 @@ public class GameManager : MonoBehaviour
                     {
                         if (ability.timing == TriggerTiming.OnCreatureDies && ability.effect != null)
                         {
-                            ability.effect.Invoke(player, card);
+                            pendingStackEffects++;
+                            StartCoroutine(ResolveTriggeredAbilityOnStack(ability, player, card, card, creature));
                         }
                     }
                 }
             }
-
-            lastDeadCreature = null;
         }
 
         public void NotifyCombatDamageToPlayer(CreatureCard attacker, Player target)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1307,6 +1307,105 @@ public class GameManager : MonoBehaviour
             }
         }
 
+    public void QueueArtifactActivatedAbility(ArtifactCard artifact, ActivatedAbility ability, Player controller, Card target = null)
+    {
+        pendingStackEffects++;
+        StartCoroutine(ResolveArtifactActivatedAbilityOnStack(artifact, ability, controller, target));
+    }
+
+    public IEnumerator ResolveArtifactActivatedAbilityOnStack(ArtifactCard artifact, ActivatedAbility ability, Player controller, Card target = null)
+    {
+        yield return new WaitUntil(() => !isStackBusy);
+        pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
+        isStackBusy = true;
+        TurnSystem.Instance.lastPhaseBeforeStack = TurnSystem.Instance.currentPhase;
+
+        GameObject stackObj = Instantiate(cardPrefab, stackZone);
+        CardVisual stackVisual = stackObj.GetComponent<CardVisual>();
+        stackVisual.Setup(artifact, this);
+        stackVisual.isInStack = true;
+        stackVisual.UpdateVisual();
+        stackVisual.transform.localPosition = Vector3.zero;
+        stackVisual.transform.localRotation = Quaternion.identity;
+        stackVisual.transform.localScale = Vector3.one;
+
+        GameObject triggerVFX = null;
+        if (triggerVFXPrefab != null)
+        {
+            triggerVFX = Instantiate(triggerVFXPrefab, stackObj.transform);
+            RectTransform rt = triggerVFX.GetComponent<RectTransform>();
+            if (rt != null)
+                rt.anchoredPosition = Vector2.zero;
+        }
+
+        yield return new WaitForSeconds(2f);
+
+        switch (ability)
+        {
+            case ActivatedAbility.TapToGainLife:
+                TryGainLife(controller, 1);
+                break;
+            case ActivatedAbility.TapToPlague:
+                humanPlayer.Life -= artifact.plagueAmount;
+                aiPlayer.Life -= artifact.plagueAmount;
+                ShowFloatingDamage(artifact.plagueAmount, playerLifeContainer);
+                ShowFloatingDamage(artifact.plagueAmount, enemyLifeContainer);
+                SoundManager.Instance.PlaySound(SoundManager.Instance.plague);
+                ShowBloodSplatVFX(artifact);
+                break;
+            case ActivatedAbility.SacrificeForLife:
+                TryGainLife(controller, artifact.lifeToGain);
+                SoundManager.Instance.PlaySound(SoundManager.Instance.drink);
+                SoundManager.Instance.PlaySound(SoundManager.Instance.gain_life);
+                break;
+            case ActivatedAbility.SacrificeToDrawCards:
+                DrawCards(controller, artifact.cardsToDraw);
+                break;
+            case ActivatedAbility.TapToPlayRandomPotion:
+                SearchLibraryForRandomPotionToBattlefield(controller);
+                break;
+            case ActivatedAbility.DealDamageToCreature:
+                if (target is CreatureCard targetCreature)
+                {
+                    targetCreature.TakeDamage(artifact.damageToCreature);
+                    Card asCard = artifact;
+                    if (asCard is CreatureCard srcCreature &&
+                        srcCreature.keywordAbilities.Contains(KeywordAbility.Deathtouch) &&
+                        artifact.damageToCreature > 0)
+                    {
+                        targetCreature.Kill();
+                    }
+                }
+                break;
+            case ActivatedAbility.BuffTargetCreature:
+                if (target is CreatureCard buffTarget)
+                {
+                    buffTarget.AddTemporaryBuff(artifact.buffPower, artifact.buffToughness);
+                    CardVisual tVis = FindCardVisual(buffTarget);
+                    if (tVis != null)
+                        tVis.UpdateVisual();
+                }
+                break;
+        }
+
+        CheckDeaths(humanPlayer);
+        CheckDeaths(aiPlayer);
+        UpdateUI();
+
+        if (triggerVFX != null)
+            Destroy(triggerVFX);
+        Destroy(stackObj);
+        isStackBusy = false;
+        CheckForGameEnd();
+
+        if (controller == aiPlayer && TurnSystem.Instance.waitingToResumeAI && pendingStackEffects == 0)
+        {
+            Debug.Log("Resuming AI phase after stack.");
+            TurnSystem.Instance.waitingToResumeAI = false;
+            TurnSystem.Instance.RunSpecificPhase(TurnSystem.Instance.lastPhaseBeforeStack);
+        }
+    }
+
     public void SummonToken(Card tokenCard, Player owner)
     {
         if (tokenCard == null)
@@ -2438,35 +2537,24 @@ public class GameManager : MonoBehaviour
                         return;
                     }
 
-                targetCreature.TakeDamage(targetingArtifact.damageToCreature);
-                Card asCard = targetingArtifact;
-                if (asCard is CreatureCard srcCreature &&
-                    srcCreature.keywordAbilities.Contains(KeywordAbility.Deathtouch) &&
-                    targetingArtifact.damageToCreature > 0)
-                {
-                    targetCreature.Kill();
+                    ArtifactCard artifact = targetingArtifact;
+                    targetingArtifact.isTapped = true;
+                    SendToGraveyard(targetingArtifact, controller);
+                    QueueArtifactActivatedAbility(artifact, ActivatedAbility.DealDamageToCreature, controller, targetCreature);
+                    UpdateUI();
                 }
-                Debug.Log($"{targetingArtifact.cardName} deals {targetingArtifact.damageToCreature} to {targetCreature.cardName}");
+                else
+                {
+                    Debug.Log("Invalid target. Artifact effect canceled.");
+                    targetingArtifact.isTapped = false;
+                }
 
-                targetingArtifact.isTapped = true;
-                SendToGraveyard(targetingArtifact, controller);
-
-                UpdateUI();
-                CheckDeaths(humanPlayer);
-                CheckDeaths(aiPlayer);
+                targetingArtifact = null;
+                targetingPlayer = null;
+                targetingVisual = null;
+                isTargetingMode = false;
+                return;
             }
-            else
-            {
-                Debug.Log("Invalid target. Artifact effect canceled.");
-                targetingArtifact.isTapped = false;
-            }
-
-            targetingArtifact = null;
-            targetingPlayer = null;
-            targetingVisual = null;
-            isTargetingMode = false;
-            return;
-        }
         // Artifact buff ability
         if (targetingArtifact != null &&
             targetingArtifact.activatedAbilities.Contains(ActivatedAbility.BuffTargetCreature))
@@ -2491,16 +2579,10 @@ public class GameManager : MonoBehaviour
                     return;
                 }
 
-                targetCreature.AddTemporaryBuff(targetingArtifact.buffPower, targetingArtifact.buffToughness);
-                Debug.Log($"{targetingArtifact.cardName} gives +{targetingArtifact.buffPower}/+{targetingArtifact.buffToughness} to {targetCreature.cardName} until end of turn");
-
-                var tVis = FindCardVisual(targetCreature);
-                if (tVis != null)
-                    tVis.UpdateVisual();
-
+                ArtifactCard artifact = targetingArtifact;
                 targetingArtifact.isTapped = true;
                 SendToGraveyard(targetingArtifact, controller);
-
+                QueueArtifactActivatedAbility(artifact, ActivatedAbility.BuffTargetCreature, controller, targetCreature);
                 UpdateUI();
             }
             else

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -854,21 +854,23 @@ public class TurnSystem : MonoBehaviour
 
                         foreach (var card in ai.Battlefield.ToList()) // .ToList() because we may remove during iteration
                         {
+                            if (GameManager.Instance.IsStackActive())
+                                break;
+
                             if (card is ArtifactCard artifact && !artifact.isTapped)
                             {
                                 if (artifact.activatedAbilities.Contains(ActivatedAbility.TapToGainLife))
                                 {
                                     artifact.isTapped = true;
-                                    GameManager.Instance.TryGainLife(ai, 1);
+                                    GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.TapToGainLife, ai);
                                     Debug.Log($"AI taps {artifact.cardName} to gain 1 life.");
                                     GameManager.Instance.FindCardVisual(artifact)?.UpdateVisual();
+                                    GameManager.Instance.UpdateUI();
                                 }
                                 else if (artifact.activatedAbilities.Contains(ActivatedAbility.TapToPlague))
                                 {
                                     artifact.isTapped = true;
-                                    GameManager.Instance.humanPlayer.Life -= artifact.plagueAmount;
-                                    GameManager.Instance.aiPlayer.Life -= artifact.plagueAmount;
-                                    GameManager.Instance.CheckForGameEnd();
+                                    GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.TapToPlague, ai);
                                     GameManager.Instance.FindCardVisual(artifact)?.UpdateVisual();
                                     GameManager.Instance.UpdateUI();
                                 }
@@ -878,10 +880,9 @@ public class TurnSystem : MonoBehaviour
                                     if (EnsureManaForCost(ai, abilityCost))
                                     {
                                         ai.ColoredMana.Pay(abilityCost);
-                                        GameManager.Instance.TryGainLife(ai, artifact.lifeToGain);
                                         artifact.isTapped = true;
                                         GameManager.Instance.SendToGraveyard(artifact, ai);
-                                        Debug.Log($"AI sacrifices {artifact.cardName} to gain {artifact.lifeToGain} life.");
+                                        GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.SacrificeForLife, ai);
                                         GameManager.Instance.FindCardVisual(artifact)?.UpdateVisual();
                                         GameManager.Instance.UpdateUI();
                                     }
@@ -893,11 +894,8 @@ public class TurnSystem : MonoBehaviour
                                     {
                                         ai.ColoredMana.Pay(abilityCost);
                                         artifact.isTapped = true;
-
-                                        GameManager.Instance.DrawCards(ai, artifact.cardsToDraw);
-
                                         GameManager.Instance.SendToGraveyard(artifact, ai);
-                                        Debug.Log($"AI sacrifices {artifact.cardName} to draw {artifact.cardsToDraw} card(s).");
+                                        GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.SacrificeToDrawCards, ai);
                                         GameManager.Instance.FindCardVisual(artifact)?.UpdateVisual();
                                         GameManager.Instance.UpdateUI();
                                     }
@@ -909,7 +907,7 @@ public class TurnSystem : MonoBehaviour
                                     {
                                         ai.ColoredMana.Pay(abilityCost);
                                         artifact.isTapped = true;
-                                        GameManager.Instance.SearchLibraryForRandomPotionToBattlefield(ai);
+                                        GameManager.Instance.QueueArtifactActivatedAbility(artifact, ActivatedAbility.TapToPlayRandomPotion, ai);
                                         GameManager.Instance.FindCardVisual(artifact)?.UpdateVisual();
                                         GameManager.Instance.UpdateUI();
                                     }


### PR DESCRIPTION
## Summary
- Route OnDeath abilities through the shared stack so multiple death triggers resolve sequentially

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*
- ⚠️ `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bce621364832781f853f1ca17e866