### PR TITLE
Route creature activated abilities through stack

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -870,7 +870,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         if (player.ColoredMana.Total() >= cost)
                         {
                             player.ColoredMana.SpendGeneric(cost);
-                            GameManager.Instance.ReturnCreatureFromGraveyardToBattlefield(player, graveCreature);
+                            GameManager.Instance.QueueCreatureActivatedAbility(graveCreature, ActivatedAbility.ReturnSelfFromGraveyard, player);
                         }
                         else
                         {
@@ -882,7 +882,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         if (player.ColoredMana.Total() >= cost)
                         {
                             player.ColoredMana.SpendGeneric(cost);
-                            GameManager.Instance.ReturnCreatureFromGraveyardToHand(player, graveCreature);
+                            GameManager.Instance.QueueCreatureActivatedAbility(graveCreature, ActivatedAbility.ReturnSelfFromGraveyardToHand, player);
                         }
                         else
                         {
@@ -1142,8 +1142,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     int remaining = cost - 1;
                     if (available >= 1 && player.ColoredMana.Total() - available >= remaining)
                     {
-                        GameManager.Instance.PayToGainAbility(abilityCreature);
-                        UpdateVisual();
+                        GameManager.Instance.QueueCreatureActivatedAbility(abilityCreature, ActivatedAbility.PayToGainAbility, player);
                     }
                     else
                     {
@@ -1154,8 +1153,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 {
                     if (player.ColoredMana.Total() >= cost)
                     {
-                        GameManager.Instance.PayToGainAbility(abilityCreature);
-                        UpdateVisual();
+                        GameManager.Instance.QueueCreatureActivatedAbility(abilityCreature, ActivatedAbility.PayToGainAbility, player);
                     }
                     else
                     {
@@ -1191,8 +1189,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
 
                     if (available >= cost)
                     {
-                        GameManager.Instance.PayToBuffSelf(pumpCreature);
-                        UpdateVisual();
+                        GameManager.Instance.QueueCreatureActivatedAbility(pumpCreature, ActivatedAbility.PayToBuffSelf, player);
                     }
                     else
                     {
@@ -1203,8 +1200,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 {
                     if (player.ColoredMana.Total() >= cost)
                     {
-                        GameManager.Instance.PayToBuffSelf(pumpCreature);
-                        UpdateVisual();
+                        GameManager.Instance.QueueCreatureActivatedAbility(pumpCreature, ActivatedAbility.PayToBuffSelf, player);
                     }
                     else
                     {
@@ -1251,23 +1247,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         }
 
                         linkedCard.isTapped = true;
-
-                        string tokenName = linkedCard.tokenToCreate;
-                        Card token = CardFactory.Create(tokenName);
-                        if (token != null)
-                        {
-                            if (tokenName == "Autonomous Miner")
-                            {
-                                SoundManager.Instance.PlaySound(SoundManager.Instance.miner);
-                            }
-                            GameManager.Instance.SummonToken(token, player);
-                            Debug.Log($"{linkedCard.cardName} created a {tokenName} token.");
-                        }
-                        else
-                        {
-                            Debug.LogError($"Failed to create token: {tokenName}");
-                        }
-
+                        GameManager.Instance.QueueCreatureActivatedAbility(tokenSpawner, ActivatedAbility.TapToCreateToken, player);
                         GameManager.Instance.UpdateUI();
                         UpdateVisual();
                     }
@@ -1288,8 +1268,10 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                     !creatureForDrain.isTapped &&
                     (!creatureForDrain.hasSummoningSickness || creatureForDrain.keywordAbilities.Contains(KeywordAbility.Haste)))
                 {
-                    GameManager.Instance.TapToLoseLife(creatureForDrain);
+                    creatureForDrain.isTapped = true;
+                    GameManager.Instance.QueueCreatureActivatedAbility(creatureForDrain, ActivatedAbility.TapToLoseLife, GameManager.Instance.humanPlayer);
                     UpdateVisual();
+                    GameManager.Instance.UpdateUI();
                     return;
                 }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1418,6 +1418,98 @@ public class GameManager : MonoBehaviour
         }
     }
 
+    public void QueueCreatureActivatedAbility(CreatureCard creature, ActivatedAbility ability, Player controller, Card target = null)
+    {
+        pendingStackEffects++;
+        StartCoroutine(ResolveCreatureActivatedAbilityOnStack(creature, ability, controller, target));
+    }
+
+    public IEnumerator ResolveCreatureActivatedAbilityOnStack(CreatureCard creature, ActivatedAbility ability, Player controller, Card target = null)
+    {
+        yield return new WaitUntil(() => !isStackBusy);
+        pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
+        isStackBusy = true;
+        TurnSystem.Instance.lastPhaseBeforeStack = TurnSystem.Instance.currentPhase;
+
+        GameObject stackObj = Instantiate(cardPrefab, stackZone);
+        CardVisual stackVisual = stackObj.GetComponent<CardVisual>();
+        stackVisual.Setup(creature, this);
+        stackVisual.isInStack = true;
+        stackVisual.UpdateVisual();
+        stackVisual.transform.localPosition = Vector3.zero;
+        stackVisual.transform.localRotation = Quaternion.identity;
+        stackVisual.transform.localScale = Vector3.one;
+
+        GameObject triggerVFX = null;
+        if (triggerVFXPrefab != null)
+        {
+            triggerVFX = Instantiate(triggerVFXPrefab, stackObj.transform);
+            RectTransform rt = triggerVFX.GetComponent<RectTransform>();
+            if (rt != null)
+                rt.anchoredPosition = Vector2.zero;
+        }
+
+        yield return new WaitForSeconds(2f);
+
+        switch (ability)
+        {
+            case ActivatedAbility.PayToGainAbility:
+                PayToGainAbility(creature);
+                break;
+            case ActivatedAbility.PayToBuffSelf:
+                PayToBuffSelf(creature);
+                break;
+            case ActivatedAbility.TapToLoseLife:
+                Player opponent = GetOpponentOf(controller);
+                opponent.Life -= creature.tapLifeLossAmount;
+                if (controller == humanPlayer)
+                    ShowFloatingDamage(creature.tapLifeLossAmount, enemyLifeContainer);
+                else
+                    ShowFloatingDamage(creature.tapLifeLossAmount, playerLifeContainer);
+                SoundManager.Instance.PlaySound(SoundManager.Instance.plague);
+                ShowBloodSplatVFX(creature);
+                break;
+            case ActivatedAbility.TapToCreateToken:
+                string tokenName = creature.tokenToCreate;
+                Card token = CardFactory.Create(tokenName);
+                if (token != null)
+                {
+                    if (tokenName == "Autonomous Miner")
+                        SoundManager.Instance.PlaySound(SoundManager.Instance.miner);
+                    SummonToken(token, controller);
+                    Debug.Log($"{creature.cardName} created a {tokenName} token.");
+                }
+                else
+                {
+                    Debug.LogError($"Failed to create token: {tokenName}");
+                }
+                break;
+            case ActivatedAbility.ReturnSelfFromGraveyard:
+                ReturnCreatureFromGraveyardToBattlefield(controller, creature);
+                break;
+            case ActivatedAbility.ReturnSelfFromGraveyardToHand:
+                ReturnCreatureFromGraveyardToHand(controller, creature);
+                break;
+        }
+
+        CheckDeaths(humanPlayer);
+        CheckDeaths(aiPlayer);
+        UpdateUI();
+
+        if (triggerVFX != null)
+            Destroy(triggerVFX);
+        Destroy(stackObj);
+        isStackBusy = false;
+        CheckForGameEnd();
+
+        if (controller == aiPlayer && TurnSystem.Instance.waitingToResumeAI && pendingStackEffects == 0)
+        {
+            Debug.Log("Resuming AI phase after stack.");
+            TurnSystem.Instance.waitingToResumeAI = false;
+            TurnSystem.Instance.RunSpecificPhase(TurnSystem.Instance.lastPhaseBeforeStack);
+        }
+    }
+
     public void SummonToken(Card tokenCard, Player owner)
     {
         if (tokenCard == null)

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -790,7 +790,8 @@ public class TurnSystem : MonoBehaviour
                                 // TAP TO LOSE LIFE
                                 if (creature.activatedAbilities.Contains(ActivatedAbility.TapToLoseLife))
                                 {
-                                    GameManager.Instance.TapToLoseLife(creature);
+                                    creature.isTapped = true;
+                                    GameManager.Instance.QueueCreatureActivatedAbility(creature, ActivatedAbility.TapToLoseLife, ai);
                                     GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
                                 }
 
@@ -805,18 +806,7 @@ public class TurnSystem : MonoBehaviour
 
                                         creature.isTapped = true;
 
-                                        string tokenName = creature.tokenToCreate;
-                                        Card token = CardFactory.Create(tokenName);
-                                        if (token != null)
-                                        {
-                                            GameManager.Instance.SummonToken(token, ai);
-                                            Debug.Log($"AI created a {tokenName} token.");
-                                        }
-                                        else
-                                        {
-                                            Debug.LogError($"AI failed to create token: {tokenName}");
-                                        }
-
+                                        GameManager.Instance.QueueCreatureActivatedAbility(creature, ActivatedAbility.TapToCreateToken, ai);
                                         GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
                                     }
                                     else
@@ -825,32 +815,32 @@ public class TurnSystem : MonoBehaviour
                                     }
                                 }
 
-                            if (creature.activatedAbilities.Contains(ActivatedAbility.PayToGainAbility) &&
-                                !creature.keywordAbilities.Contains(creature.abilityToGain))
-                            {
-                                int cost = creature.manaToPayToActivate;
-                                string color = creature.PrimaryColor;
-                                var abilityCost = new Dictionary<string, int>();
+                                if (creature.activatedAbilities.Contains(ActivatedAbility.PayToGainAbility) &&
+                                    !creature.keywordAbilities.Contains(creature.abilityToGain))
+                                {
+                                    int cost = creature.manaToPayToActivate;
+                                    string color = creature.PrimaryColor;
+                                    var abilityCost = new Dictionary<string, int>();
 
-                                if (!string.IsNullOrEmpty(color) && color != "Artifact")
-                                {
-                                    abilityCost[color] = 1;
-                                    if (cost > 1)
-                                        abilityCost["Colorless"] = cost - 1;
-                                }
-                                else
-                                {
-                                    abilityCost["Colorless"] = cost;
-                                }
+                                    if (!string.IsNullOrEmpty(color) && color != "Artifact")
+                                    {
+                                        abilityCost[color] = 1;
+                                        if (cost > 1)
+                                            abilityCost["Colorless"] = cost - 1;
+                                    }
+                                    else
+                                    {
+                                        abilityCost["Colorless"] = cost;
+                                    }
 
-                                if (EnsureManaForCost(ai, abilityCost))
-                                {
-                                    GameManager.Instance.PayToGainAbility(creature);
-                                    GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
+                                    if (EnsureManaForCost(ai, abilityCost))
+                                    {
+                                        GameManager.Instance.QueueCreatureActivatedAbility(creature, ActivatedAbility.PayToGainAbility, ai);
+                                        GameManager.Instance.FindCardVisual(creature)?.UpdateVisual();
+                                    }
                                 }
                             }
                             }
-                        }
 
                         foreach (var card in ai.Battlefield.ToList()) // .ToList() because we may remove during iteration
                         {


### PR DESCRIPTION
## Summary
- Add stack support for creature activated abilities
- Queue creature abilities from player interactions and AI decisions
- Resolve creature ability effects via stack except for mana abilities

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd8a3fc0c83278532b59fabd5d48c