### PR TITLE
Remove tapped clause from graveyard return ability

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -182,7 +182,7 @@ public class Card
                                     lines.Add($"{creature.manaToPayToActivate}: +1/+0 until end of turn.");
                                     break;
                                 case ActivatedAbility.ReturnSelfFromGraveyard:
-                                    lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to the battlefield tapped.");
+                                    lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to the battlefield.");
                                     break;
                                 case ActivatedAbility.ReturnSelfFromGraveyardToHand:
                                     lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to your hand.");

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -2021,10 +2021,10 @@ public class GameManager : MonoBehaviour
         player.Battlefield.Add(creature);
 
         creature.hasSummoningSickness = true;
-        if (creature.entersTapped || IsAllPermanentsEnterTappedActive())
+        if (IsAllPermanentsEnterTappedActive())
         {
             creature.isTapped = true;
-            Debug.Log($"{creature.cardName} enters tapped from graveyard.");
+            Debug.Log($"{creature.cardName} enters tapped from graveyard due to global effect.");
         }
 
         GameObject obj = Instantiate(cardPrefab, player == humanPlayer ? playerBattlefieldArea : aiBattlefieldArea);


### PR DESCRIPTION
## Summary
- Stop auto-tapping creatures returned from the graveyard
- Remove "tapped" from graveyard return ability text

## Testing
- `dotnet test` (fails: command not found)
- `apt-get update` (fails: repository not signed/403)

------
https://chatgpt.com/codex/tasks/task_e_689ca637a83c8327be11e2e095ee3f58