### PR TITLE
Support Instant card type using sorcery behavior

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2391,7 +2391,7 @@ public static class CardDatabase
                 Add(new CardData { //Exorcism
                     cardName = "Exorcism",
                     rarity = "Common",
-                    cardType = CardType.Sorcery,
+                    cardType = CardType.Instant,
                     manaCost = 2,
                     color = new List<string> { "White" },
                     requiresTarget = true,

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -42,6 +42,7 @@ public static class CardFactory
                 newCard = creature;
                 break;
             case CardType.Sorcery:
+            case CardType.Instant:
                 SorceryCard sorcery = new SorceryCard();
                 sorcery.lifeToGain = data.lifeToGain;
                 sorcery.lifeToLoseForOpponent = data.lifeToLoseForOpponent;

--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -114,7 +114,12 @@ public class DeckEditorManager : MonoBehaviour
             }
             else if (filter == "Creature" || filter == "Sorcery" || filter == "Enchantment")
             {
-                if (data.cardType.ToString() != filter)
+                if (filter == "Sorcery")
+                {
+                    if (data.cardType != CardType.Sorcery && data.cardType != CardType.Instant)
+                        return false;
+                }
+                else if (data.cardType.ToString() != filter)
                     return false;
             }
             else if (!colors.Contains(filter))


### PR DESCRIPTION
## Summary
- Allow `CardFactory` to create sorcery-style cards for the Instant card type
- Treat Instants as sorceries in deck filter logic
- Mark "Exorcism" as an Instant in the card database

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689efc05dc6c83278df332dc7aa2eac1