### PR TITLE
Add combat damage prevention instant

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -126,6 +126,7 @@ public class Card
                     if (keyword == KeywordAbility.CantBlock ||
                         keyword == KeywordAbility.CanOnlyBlockFlying ||
                         keyword == KeywordAbility.CantBlockWithoutForest ||
+                        keyword == KeywordAbility.CantDealCombatDamage ||
                         keyword == KeywordAbility.BeastCreatureSpellsCostOneLess ||
                         keyword == KeywordAbility.PotionSpellsCostOneLess ||
                         keyword.ToString().StartsWith("ProtectionFrom"))
@@ -144,6 +145,8 @@ public class Card
                     lines.Add("This creature enters the battlefield tapped.");
                 if (creature.keywordAbilities.Contains(KeywordAbility.CantUntap))
                     lines.Add("This creature doesn't untap during its controller's untap step.");
+                if (creature.keywordAbilities.Contains(KeywordAbility.CantDealCombatDamage))
+                    lines.Add("This creature can't deal combat damage.");
                 if (creature.keywordAbilities.Contains(KeywordAbility.ProtectionFromWhite))
                     lines.Add("Protection from White");
                 if (creature.keywordAbilities.Contains(KeywordAbility.ProtectionFromBlue))

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2464,6 +2464,19 @@ public static class CardDatabase
                     artwork = Resources.Load<Sprite>("Art/bells_call"),
                     abilities = new List<CardAbility>(),
                     });
+                Add(new CardData //Stay the Blade
+                    {
+                    cardName = "Stay the Blade",
+                    rarity = "Common",
+                    cardType = CardType.Instant,
+                    manaCost = 1,
+                    color = new List<string> { "White" },
+                    requiresTarget = true,
+                    requiredTargetType = SorceryCard.TargetType.Creature,
+                    keywordToGrant = KeywordAbility.CantDealCombatDamage,
+                    rulesText = "Prevent all combat damage that target creature would deal this turn.",
+                    artwork = Resources.Load<Sprite>("Art/faith_protection"),
+                    });
             //BLUE
                 Add(new CardData { //Blast of knowledge
                     cardName = "Blast of Knowledge",

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -781,8 +781,10 @@ public class GameManager : MonoBehaviour
 
         foreach (var attacker in currentAttackers)
         {
-            // Clamp negative power to zero when dealing damage
-            int attackerDamage = Mathf.Max(attacker.power, 0);
+            // Clamp negative power to zero when dealing damage and handle damage prevention
+            int attackerDamage = attacker.keywordAbilities.Contains(KeywordAbility.CantDealCombatDamage)
+                ? 0
+                : Mathf.Max(attacker.power, 0);
             var blockers = attacker.blockedByThisBlocker;
 
             if (blockers != null && blockers.Count > 0)
@@ -812,7 +814,9 @@ public class GameManager : MonoBehaviour
                         remainingDamage -= damageToBlocker;
                     }
 
-                    int damageFromBlocker = attackerProtected ? 0 : Mathf.Max(blocker.power, 0);
+                    int damageFromBlocker = (attackerProtected || blocker.keywordAbilities.Contains(KeywordAbility.CantDealCombatDamage))
+                        ? 0
+                        : Mathf.Max(blocker.power, 0);
                     if (!attackerProtected)
                     {
                         totalDamageFromBlockers += damageFromBlocker;
@@ -3598,8 +3602,10 @@ public class GameManager : MonoBehaviour
                 int playerDamage = 0;
                 int aiDamage = 0;
 
-                // Clamp negative power to zero when dealing damage
-                int attackerDamage = Mathf.Max(attacker.power, 0);
+                // Clamp negative power to zero when dealing damage and respect damage prevention
+                int attackerDamage = attacker.keywordAbilities.Contains(KeywordAbility.CantDealCombatDamage)
+                    ? 0
+                    : Mathf.Max(attacker.power, 0);
 
                 var blockers = attacker.blockedByThisBlocker;
 
@@ -3630,7 +3636,9 @@ public class GameManager : MonoBehaviour
                             remainingDamage -= damageToBlocker;
                         }
 
-                        int damageFromBlocker = attackerProtected ? 0 : Mathf.Max(blocker.power, 0);
+                        int damageFromBlocker = (attackerProtected || blocker.keywordAbilities.Contains(KeywordAbility.CantDealCombatDamage))
+                            ? 0
+                            : Mathf.Max(blocker.power, 0);
                         if (!attackerProtected)
                         {
                             totalDamageFromBlockers += damageFromBlocker;

--- a/Assets/Scripts/KeywordAbility.cs
+++ b/Assets/Scripts/KeywordAbility.cs
@@ -31,6 +31,7 @@ public enum KeywordAbility
     PotionSpellsCostOneLess,
     OpponentSpellsCostOneMore,
     CantUntap,
+    CantDealCombatDamage,
 }
 
 public enum ActivatedAbility


### PR DESCRIPTION
## Summary
- add common white instant Stay the Blade that stops target creature's combat damage
- introduce CantDealCombatDamage keyword
- handle damage-prevention ability in combat resolution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2c8c2150832782755fdeeeaf2692