### PR TITLE
Add multi-effect artifact support with choice UI

### DIFF
--- a/Assets/Scripts/ArtifactCard.cs
+++ b/Assets/Scripts/ArtifactCard.cs
@@ -19,7 +19,12 @@ public class ArtifactCard : Card
                     break;
 
                 case ActivatedAbility.TapToGainLife:
-                    GameManager.Instance.TryGainLife(owner, 1);
+                    int gain = lifeToGain > 0 ? lifeToGain : 1;
+                    GameManager.Instance.TryGainLife(owner, gain);
+                    break;
+
+                case ActivatedAbility.TapToDrawCards:
+                    GameManager.Instance.DrawCards(owner, cardsToDraw);
                     break;
 
                 case ActivatedAbility.TapAndSacrificeForMana:

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -207,44 +207,51 @@ public class Card
 
                 if (activatedAbilities != null)
                 {
-                    foreach (var activated in activatedAbilities)
+                    if (activatedAbilities.Count == 1)
                     {
-                        switch (activated)
+                        foreach (var activated in activatedAbilities)
                         {
-                            case ActivatedAbility.TapForMana:
-                                lines.Add("Tap: Add 1 mana.");
-                                break;
-                            case ActivatedAbility.TapToGainLife:
-                                lines.Add("Tap: Gain 1 life.");
-                                //lines.Add($"Tap: Gain {plagueAmount} life.");
-                                break;
-                            case ActivatedAbility.TapAndSacrificeForMana:
-                                lines.Add("Tap, sacrifice: Add 1 mana.");
-                                break;
-                            case ActivatedAbility.TapToPlague:
-                                lines.Add($"Tap: Each player loses {plagueAmount} life.");
-                                break;
-                            case ActivatedAbility.SacrificeForMana:
-                                lines.Add($"{manaToPayToActivate}TAP, sacrifice: Add {manaToGain}.");
-                                break;
-                            case ActivatedAbility.SacrificeForLife:
-                                lines.Add($"{manaToPayToActivate}TAP, sacrifice: Gain {lifeToGain} life.");
-                                break;
-                            case ActivatedAbility.SacrificeToDrawCards:
-                                lines.Add($"{manaToPayToActivate}TAP, sacrifice: Draw {cardsToDraw} card(s).");
-                                break;
-                            case ActivatedAbility.DealDamageToCreature:
-                                    lines.Add($"{manaToPayToActivate}TAP, sacrifice: Deal {damageToCreature} damage to target creature.");
+                            switch (activated)
+                            {
+                                case ActivatedAbility.TapForMana:
+                                    lines.Add("Tap: Add 1 mana.");
                                     break;
-                            case ActivatedAbility.BuffTargetCreature:
-                                lines.Add($"{manaToPayToActivate}TAP, sacrifice: Target creature gets +{buffPower}/+{buffToughness} until end of turn.");
-                                break;
-                            case ActivatedAbility.TapToPlayRandomPotion:
-                                lines.Add($"{manaToPayToActivate}TAP: Search your library for a random Potion and put it onto the battlefield, then shuffle.");
-                                break;
-                            case ActivatedAbility.Equip:
-                                lines.Add($"Equip {manaToPayToActivate}");
-                                break;
+                                case ActivatedAbility.TapToGainLife:
+                                    int gain = artifact.lifeToGain > 0 ? artifact.lifeToGain : 1;
+                                    lines.Add($"Tap: Gain {gain} life.");
+                                    //lines.Add($"Tap: Gain {plagueAmount} life.");
+                                    break;
+                                case ActivatedAbility.TapToDrawCards:
+                                    lines.Add($"Tap: Draw {artifact.cardsToDraw} card(s).");
+                                    break;
+                                case ActivatedAbility.TapAndSacrificeForMana:
+                                    lines.Add("Tap, sacrifice: Add 1 mana.");
+                                    break;
+                                case ActivatedAbility.TapToPlague:
+                                    lines.Add($"Tap: Each player loses {plagueAmount} life.");
+                                    break;
+                                case ActivatedAbility.SacrificeForMana:
+                                    lines.Add($"{manaToPayToActivate}TAP, sacrifice: Add {manaToGain}.");
+                                    break;
+                                case ActivatedAbility.SacrificeForLife:
+                                    lines.Add($"{manaToPayToActivate}TAP, sacrifice: Gain {lifeToGain} life.");
+                                    break;
+                                case ActivatedAbility.SacrificeToDrawCards:
+                                    lines.Add($"{manaToPayToActivate}TAP, sacrifice: Draw {cardsToDraw} card(s).");
+                                    break;
+                                case ActivatedAbility.DealDamageToCreature:
+                                        lines.Add($"{manaToPayToActivate}TAP, sacrifice: Deal {damageToCreature} damage to target creature.");
+                                        break;
+                                case ActivatedAbility.BuffTargetCreature:
+                                    lines.Add($"{manaToPayToActivate}TAP, sacrifice: Target creature gets +{buffPower}/+{buffToughness} until end of turn.");
+                                    break;
+                                case ActivatedAbility.TapToPlayRandomPotion:
+                                    lines.Add($"{manaToPayToActivate}TAP: Search your library for a random Potion and put it onto the battlefield, then shuffle.");
+                                    break;
+                                case ActivatedAbility.Equip:
+                                    lines.Add($"Equip {manaToPayToActivate}");
+                                    break;
+                            }
                         }
                     }
                 }

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -3114,6 +3114,25 @@ public static class CardDatabase
                         artwork = Resources.Load<Sprite>("Art/battle_shield")
                     });
 
+                Add(new CardData // Baton of Power
+                    {
+                        cardName = "Baton of Power",
+                        rarity = "Rare",
+                        manaCost = 4,
+                        color = new List<string>(),
+                        cardType = CardType.Artifact,
+                        lifeToGain = 3,
+                        cardsToDraw = 1,
+                        manaToPayToActivate = 4,
+                        activatedAbilities = new List<ActivatedAbility>
+                        {
+                            ActivatedAbility.TapToGainLife,
+                            ActivatedAbility.TapToDrawCards
+                        },
+                        rulesText = "Tap, pay 4: Choose one - you gain 3 life or you draw a card.",
+                        artwork = Resources.Load<Sprite>("Art/baton_of_power")
+                    });
+
                 // Avatar cycle gaining +1/+1 counters
                 Add(new CardData //Progress Incarnate
                     {

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1114,6 +1114,46 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 return;
             }
 
+            // Multiple-choice artifact activations
+            if (linkedCard is ArtifactCard choiceArtifact &&
+                choiceArtifact.activatedAbilities != null &&
+                choiceArtifact.activatedAbilities.Count > 1 &&
+                !linkedCard.isTapped &&
+                GameManager.Instance.humanPlayer.Battlefield.Contains(linkedCard) &&
+                canActivateArtifact)
+            {
+                Player player = GameManager.Instance.humanPlayer;
+                int cost = choiceArtifact.manaToPayToActivate;
+
+                if (player.ColoredMana.Total() >= cost)
+                {
+                    int remaining = cost;
+                    remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Colorless, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.White, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Blue, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Black, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Red, remaining);
+                    remaining -= Player.ManaPool.SpendFromPool(ref player.ColoredMana.Green, remaining);
+
+                    if (remaining > 0)
+                    {
+                        Debug.Log("Not enough mana to activate artifact.");
+                        return;
+                    }
+
+                    linkedCard.isTapped = true;
+                    GameManager.Instance.BeginArtifactAbilityChoice(choiceArtifact);
+                    UpdateVisual();
+                    GameManager.Instance.UpdateUI();
+                }
+                else
+                {
+                    Debug.Log("Not enough mana to activate artifact.");
+                }
+
+                return;
+            }
+
             // PAY-TO-GAIN-ABILITY during Main Phase
                 if (linkedCard is CreatureCard abilityCreature &&
                 GameManager.Instance.humanPlayer.Battlefield.Contains(abilityCreature) &&
@@ -1355,12 +1395,28 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             // TAP-TO-GAIN-LIFE ability
                 if (linkedCard.activatedAbilities != null &&
                     linkedCard.activatedAbilities.Contains(ActivatedAbility.TapToGainLife) &&
+                    linkedCard.activatedAbilities.Count == 1 &&
                     !linkedCard.isTapped &&
                     GameManager.Instance.humanPlayer.Battlefield.Contains(linkedCard) &&
                     canActivateArtifact)
                 {
                     linkedCard.isTapped = true;
                     GameManager.Instance.QueueArtifactActivatedAbility(linkedCard as ArtifactCard, ActivatedAbility.TapToGainLife, GameManager.Instance.humanPlayer);
+                    UpdateVisual();
+                    GameManager.Instance.UpdateUI();
+                    return;
+                }
+
+            // TAP-TO-DRAW-CARDS ability
+                if (linkedCard.activatedAbilities != null &&
+                    linkedCard.activatedAbilities.Contains(ActivatedAbility.TapToDrawCards) &&
+                    linkedCard.activatedAbilities.Count == 1 &&
+                    !linkedCard.isTapped &&
+                    GameManager.Instance.humanPlayer.Battlefield.Contains(linkedCard) &&
+                    canActivateArtifact)
+                {
+                    linkedCard.isTapped = true;
+                    GameManager.Instance.QueueArtifactActivatedAbility(linkedCard as ArtifactCard, ActivatedAbility.TapToDrawCards, GameManager.Instance.humanPlayer);
                     UpdateVisual();
                     GameManager.Instance.UpdateUI();
                     return;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -111,6 +111,10 @@ public class GameManager : MonoBehaviour
     public CardAbility optionalAbility;
     public Player optionalTargetPlayer;
 
+    private GameObject abilityChoicePanel;
+    private ArtifactCard abilityChoiceArtifact;
+    private Player abilityChoicePlayer;
+
     private struct TriggeredAbilityContext
     {
         public CardAbility ability;
@@ -1378,7 +1382,11 @@ public class GameManager : MonoBehaviour
         switch (ability)
         {
             case ActivatedAbility.TapToGainLife:
-                TryGainLife(controller, 1);
+                int gain = artifact.lifeToGain > 0 ? artifact.lifeToGain : 1;
+                TryGainLife(controller, gain);
+                break;
+            case ActivatedAbility.TapToDrawCards:
+                DrawCards(controller, artifact.cardsToDraw);
                 break;
             case ActivatedAbility.TapToPlague:
                 humanPlayer.Life -= artifact.plagueAmount;
@@ -2960,6 +2968,86 @@ public class GameManager : MonoBehaviour
 
             UpdateUI();
         }
+
+    public void BeginArtifactAbilityChoice(ArtifactCard artifact)
+    {
+        abilityChoiceArtifact = artifact;
+        abilityChoicePlayer = GetOwnerOfCard(artifact);
+
+        GameObject canvasObj = GameObject.Find("Canvas");
+        if (canvasObj == null)
+            return;
+
+        abilityChoicePanel = new GameObject("AbilityChoicePanel", typeof(RectTransform), typeof(Image));
+        abilityChoicePanel.transform.SetParent(canvasObj.transform, false);
+        RectTransform rt = abilityChoicePanel.GetComponent<RectTransform>();
+        rt.anchorMin = Vector2.zero;
+        rt.anchorMax = Vector2.one;
+        rt.offsetMin = Vector2.zero;
+        rt.offsetMax = Vector2.zero;
+        Image img = abilityChoicePanel.GetComponent<Image>();
+        img.color = new Color(0, 0, 0, 0.5f);
+        img.raycastTarget = true;
+
+        VerticalLayoutGroup layout = abilityChoicePanel.AddComponent<VerticalLayoutGroup>();
+        layout.childAlignment = TextAnchor.MiddleCenter;
+        layout.spacing = 10f;
+
+        foreach (var ability in artifact.activatedAbilities)
+        {
+            GameObject btnObj = new GameObject("AbilityButton", typeof(RectTransform), typeof(Image), typeof(Button));
+            btnObj.transform.SetParent(abilityChoicePanel.transform, false);
+            Image bImg = btnObj.GetComponent<Image>();
+            bImg.color = Color.white;
+            Button btn = btnObj.GetComponent<Button>();
+
+            GameObject textObj = new GameObject("Text", typeof(RectTransform), typeof(TMP_Text));
+            textObj.transform.SetParent(btnObj.transform, false);
+            RectTransform textRt = textObj.GetComponent<RectTransform>();
+            textRt.anchorMin = Vector2.zero;
+            textRt.anchorMax = Vector2.one;
+            textRt.offsetMin = Vector2.zero;
+            textRt.offsetMax = Vector2.zero;
+            TMP_Text txt = textObj.GetComponent<TMP_Text>();
+            txt.text = GetAbilityChoiceDescription(artifact, ability);
+            txt.alignment = TextAlignmentOptions.Center;
+            txt.color = Color.black;
+
+            ActivatedAbility captured = ability;
+            btn.onClick.AddListener(() => ResolveArtifactAbilityChoice(captured));
+        }
+    }
+
+    private string GetAbilityChoiceDescription(ArtifactCard artifact, ActivatedAbility ability)
+    {
+        switch (ability)
+        {
+            case ActivatedAbility.TapToGainLife:
+                int gain = artifact.lifeToGain > 0 ? artifact.lifeToGain : 1;
+                return $"Gain {gain} life";
+            case ActivatedAbility.TapToDrawCards:
+                return $"Draw {artifact.cardsToDraw} card{(artifact.cardsToDraw == 1 ? string.Empty : "s")}";
+            default:
+                return ability.ToString();
+        }
+    }
+
+    private void ResolveArtifactAbilityChoice(ActivatedAbility ability)
+    {
+        if (abilityChoicePanel != null)
+            Destroy(abilityChoicePanel);
+
+        ArtifactCard artifact = abilityChoiceArtifact;
+        Player controller = abilityChoicePlayer;
+        abilityChoicePanel = null;
+        abilityChoiceArtifact = null;
+        abilityChoicePlayer = null;
+
+        if (artifact != null && controller != null)
+            QueueArtifactActivatedAbility(artifact, ability, controller);
+
+        UpdateUI();
+    }
 
     public void CompletePlayerTargetSelection(Player targetPlayer)
         {

--- a/Assets/Scripts/KeywordAbility.cs
+++ b/Assets/Scripts/KeywordAbility.cs
@@ -42,6 +42,7 @@ public enum ActivatedAbility
     SacrificeForMana,
     SacrificeForLife,
     TapToGainLife,
+    TapToDrawCards,
     TapToPlague,
     SacrificeToDrawCards,
     TapToCreateToken,


### PR DESCRIPTION
## Summary
- allow artifacts with multiple activated effects to present buttons and run the chosen effect
- introduce `TapToDrawCards` ability and general handling for drawing via artifacts
- add **Baton of Power**, a rare artifact that lets players gain life or draw a card

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c32ff648327a89e1d3775330ef7