### PR TITLE
Add lightning strike VFX when permanents enter tapped

### DIFF
--- a/Assets/Prefab/LightningVFX.prefab
+++ b/Assets/Prefab/LightningVFX.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &846862962743996107
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6430741675226542737}
+  - component: {fileID: 2365632737239640651}
+  - component: {fileID: 5594080556980235811}
+  m_Layer: 0
+  m_Name: LightningVFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6430741675226542737
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846862962743996107}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.6981308, y: 0.83381927, z: 61.742176}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2365632737239640651
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846862962743996107}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 57d347d4543187d41a147fad25feee4f, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.25, y: 1.25}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &5594080556980235811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846862962743996107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ef5e6846df2849418a6000ec0f598e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  duration: 1.5

--- a/Assets/Prefab/LightningVFX.prefab.meta
+++ b/Assets/Prefab/LightningVFX.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af4c5172359d4c7f8f91f4c14df70a02
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -6165,6 +6165,7 @@ MonoBehaviour:
   floatingDamagePrefab: {fileID: 6263719099324857846, guid: dbcb8822c50f8d6418d4bbed97b45924, type: 3}
   favouritePopupPrefab: {fileID: 8843468045292096794, guid: 2a04a38c796e1d746aae986d01f35727, type: 3}
   triggerVFXPrefab: {fileID: 6166682046645345468, guid: 30452ca31a8ab3e4bacd17dd8910acbf, type: 3}
+  lightningVFXPrefab: {fileID: 846862962743996107, guid: af4c5172359d4c7f8f91f4c14df70a02, type: 3}
   blueIcon: {fileID: 21300000, guid: cf5da0752d7da9f4db791fed64ba1347, type: 3}
   whiteIcon: {fileID: 21300000, guid: e51d0f0e20f24834f893872fd6719259, type: 3}
   blackIcon: {fileID: 21300000, guid: 45c943c1120a5e74dbfdc1bf4d6a0e44, type: 3}

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -50,6 +50,7 @@ public class GameManager : MonoBehaviour
     public GameObject floatingDamagePrefab;
     public GameObject favouritePopupPrefab;
     public GameObject triggerVFXPrefab;
+    public GameObject lightningVFXPrefab;
 
     // Tracks cumulative life changes during a combat step
     private TMP_Text playerLifeDeltaText;
@@ -310,10 +311,14 @@ public class GameManager : MonoBehaviour
                 player.Hand.Remove(card);
                 player.hasPlayedLandThisTurn = true;
 
-                if (card.entersTapped || GameManager.Instance.IsAllPermanentsEnterTappedActive())
+                if (card.entersTapped || IsAllPermanentsEnterTappedActive())
                 {
                     card.isTapped = true;
                     Debug.Log($"{card.cardName} enters tapped (static effect or base).");
+                    if (IsAllPermanentsEnterTappedActive())
+                    {
+                        ShowLightningStrikeVFX(card);
+                    }
                 }
 
                 card.OnEnterPlay(player);
@@ -1087,6 +1092,10 @@ public class GameManager : MonoBehaviour
             {
                 creature.isTapped = true;
                 Debug.Log($"{creature.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(creature);
+                }
             }
 
             Transform battlefield = caster == humanPlayer ? playerBattlefieldArea : aiBattlefieldArea;
@@ -1155,6 +1164,10 @@ public class GameManager : MonoBehaviour
             {
                 artifact.isTapped = true;
                 Debug.Log($"{artifact.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(artifact);
+                }
             }
 
             Transform area = caster == humanPlayer ? playerArtifactArea : aiArtifactArea;
@@ -1194,6 +1207,10 @@ public class GameManager : MonoBehaviour
             {
                 enchantment.isTapped = true;
                 Debug.Log($"{enchantment.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(enchantment);
+                }
             }
 
             Transform area = caster == humanPlayer ? playerEnchantmentArea : aiEnchantmentArea;
@@ -1250,6 +1267,10 @@ public class GameManager : MonoBehaviour
             {
                 aura.isTapped = true;
                 Debug.Log($"{aura.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(aura);
+                }
             }
 
             Transform area = caster == humanPlayer ? playerEnchantmentArea : aiEnchantmentArea;
@@ -1548,10 +1569,14 @@ public class GameManager : MonoBehaviour
         {
             creature.hasSummoningSickness = true;
 
-            if (creature.entersTapped || GameManager.Instance.IsAllPermanentsEnterTappedActive())
+            if (creature.entersTapped || IsAllPermanentsEnterTappedActive())
             {
                 creature.isTapped = true;
                 Debug.Log($"{creature.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(creature);
+                }
             }
         }
 
@@ -1699,6 +1724,10 @@ public class GameManager : MonoBehaviour
             {
                 creature.isTapped = true;
                 Debug.Log($"{creature.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(creature);
+                }
             }
         }
         else if (chosen is ArtifactCard artifact)
@@ -1707,6 +1736,10 @@ public class GameManager : MonoBehaviour
             {
                 artifact.isTapped = true;
                 Debug.Log($"{artifact.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(artifact);
+                }
             }
         }
 
@@ -1790,6 +1823,10 @@ public class GameManager : MonoBehaviour
             {
                 creature.isTapped = true;
                 Debug.Log($"{creature.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(creature);
+                }
             }
         }
         else if (chosen is ArtifactCard artifact)
@@ -1798,6 +1835,10 @@ public class GameManager : MonoBehaviour
             {
                 artifact.isTapped = true;
                 Debug.Log($"{artifact.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(artifact);
+                }
             }
         }
 
@@ -1946,6 +1987,10 @@ public class GameManager : MonoBehaviour
             {
                 creature.isTapped = true;
                 Debug.Log($"{creature.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(creature);
+                }
             }
         }
 
@@ -1991,6 +2036,10 @@ public class GameManager : MonoBehaviour
             {
                 creature.isTapped = true;
                 Debug.Log($"{creature.cardName} enters tapped (due to static effect).");
+                if (IsAllPermanentsEnterTappedActive())
+                {
+                    ShowLightningStrikeVFX(creature);
+                }
             }
         }
 
@@ -2126,6 +2175,32 @@ public class GameManager : MonoBehaviour
         GameObject vfx = Instantiate(bloodSplatPrefab, spawnPos, Quaternion.identity);
         Destroy(vfx, 1.5f);
         Debug.Log("Spawned blood VFX at " + spawnPos);
+    }
+
+    public void ShowLightningStrikeVFX(Card card)
+    {
+        Debug.Log("ShowLightningStrikeVFX triggered on: " + card.cardName);
+
+        CardVisual visual = FindCardVisual(card);
+        if (visual == null)
+        {
+            Debug.LogWarning("No visual found for card " + card.cardName);
+            return;
+        }
+
+        Vector3 spawnPos = visual.transform.position;
+        spawnPos.z = 0f;
+        spawnPos += new Vector3(Random.Range(-0.1f, 0.1f), Random.Range(-0.1f, 0.1f), 0);
+
+        if (lightningVFXPrefab == null)
+        {
+            Debug.LogWarning("lightningVFXPrefab not assigned");
+            return;
+        }
+
+        GameObject vfx = Instantiate(lightningVFXPrefab, spawnPos, Quaternion.identity);
+        Destroy(vfx, 1.5f);
+        Debug.Log("Spawned lightning VFX at " + spawnPos);
     }
 
     public void PayToGainAbility(CreatureCard creature)


### PR DESCRIPTION
## Summary
- add lightning VFX prefab field and spawn method
- show lightning VFX when permanents enter tapped due to global effect
- include LightningVFX prefab and assign in scene

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bc5504b48327a5fc75cb4a21a8e8