### PR TITLE
Add Spinewall Cactus blocking buff card

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -287,6 +287,8 @@ public class Card
                     lines.Add("Whenever a creature dies or is discarded, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnPlayerDiscard)
                     lines.Add("Whenever a player discards a card, " + ability.description);
+                else if (ability.timing == TriggerTiming.OnBlock)
+                    lines.Add("When this creature blocks, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnCombatDamageToPlayer)
                     lines.Add("Whenever a creature deals combat damage to a player, " + ability.description);
                 else if (ability.timing == TriggerTiming.OnOpponentDiscard)

--- a/Assets/Scripts/CardAbility.cs
+++ b/Assets/Scripts/CardAbility.cs
@@ -15,6 +15,7 @@ public enum TriggerTiming
     OnCreatureDiesOrDiscarded,
     OnPlayerDiscard,
     OnOpponentDiscard,
+    OnBlock,
     OnCombatDamageToPlayer,
 }
 

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -1678,6 +1678,43 @@ public static class CardDatabase
                         ActivatedAbility.TapForMana
                     }
                     });
+                Add(new CardData //Spinewall Cactus
+                    {
+                    cardName = "Spinewall Cactus",
+                    rarity = "Common",
+                    manaCost = 1,
+                    color = new List<string> { "Green" },
+                    cardType = CardType.Creature,
+                    power = 0,
+                    toughness = 2,
+                    subtypes = new List<string> { "Plant" },
+                    artwork = Resources.Load<Sprite>("Art/spinewall_cactus"),
+                    keywordAbilities = new List<KeywordAbility>
+                    {
+                        KeywordAbility.Defender
+                    },
+                    abilities = new List<CardAbility>
+                    {
+                        new CardAbility
+                        {
+                            timing = TriggerTiming.OnBlock,
+                            description = "it gets +X/+0 until end of turn where X is the power of the blocked creature.",
+                            effect = (Player owner, Card target) =>
+                            {
+                                var self = GameManager.Instance.lastAbilitySource as CreatureCard;
+                                var attacker = target as CreatureCard;
+                                if (self != null && attacker != null)
+                                {
+                                    self.AddTemporaryBuff(attacker.power, 0);
+                                    var vis = GameManager.Instance.FindCardVisual(self);
+                                    if (vis != null)
+                                        vis.UpdateVisual();
+                                    Debug.Log($"{self.cardName} blocks {attacker.cardName} and gets +{attacker.power}/+0 until end of turn.");
+                                }
+                            }
+                        }
+                    }
+                    });
                 Add(new CardData //Cactusaurus
                     {
                     cardName = "Cactusaurus",

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1674,6 +1674,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         // Assign the block
                         blocker.blockingThisAttacker = clickedCreature;
                         clickedCreature.blockedByThisBlocker.Add(blocker);
+                        GameManager.Instance.NotifyCreatureBlocks(blocker, clickedCreature);
                         GameManager.Instance.selectedBlockerForBlocking = null;
 
                         Debug.Log($"{blocker.cardName} is blocking {clickedCreature.cardName}");

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -4197,6 +4197,24 @@ public class GameManager : MonoBehaviour
             }
         }
 
+        public void NotifyCreatureBlocks(CreatureCard blocker, CreatureCard attacker)
+        {
+            if (blocker == null || attacker == null)
+                return;
+
+            Player owner = GetOwnerOfCard(blocker);
+            if (owner == null)
+                return;
+
+            foreach (var ability in blocker.abilities)
+            {
+                if (ability.timing == TriggerTiming.OnBlock && ability.effect != null)
+                {
+                    QueueTriggeredAbility(ability, owner, blocker, attacker);
+                }
+            }
+        }
+
         public void GainLife(Player player, int amount)
         {
             TryGainLife(player, amount);

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1048,6 +1048,7 @@ public class TurnSystem : MonoBehaviour
                                     GameManager.Instance.blockingAssignments[attacker].Add(blocker);
                                     blocker.blockingThisAttacker = attacker;
                                     attacker.blockedByThisBlocker.Add(blocker);
+                                    GameManager.Instance.NotifyCreatureBlocks(blocker, attacker);
                                     availableBlockers.Remove(blocker);
                                     Debug.Log($"AI blocks {attacker.cardName} with {blocker.cardName}");
                                 }


### PR DESCRIPTION
## Summary
- support block-triggered abilities with new `OnBlock` timing and notifications
- add Spinewall Cactus, a 1-mana green Defender that gains power equal to its blocker's power

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e6bc937c8327a53b8ccf82011e0a