### PR TITLE
Trigger Spinewall Cactus on blocker confirmation

### DIFF
--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -1674,7 +1674,6 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                         // Assign the block
                         blocker.blockingThisAttacker = clickedCreature;
                         clickedCreature.blockedByThisBlocker.Add(blocker);
-                        GameManager.Instance.NotifyCreatureBlocks(blocker, clickedCreature);
                         GameManager.Instance.selectedBlockerForBlocking = null;
 
                         Debug.Log($"{blocker.cardName} is blocking {clickedCreature.cardName}");

--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1048,7 +1048,6 @@ public class TurnSystem : MonoBehaviour
                                     GameManager.Instance.blockingAssignments[attacker].Add(blocker);
                                     blocker.blockingThisAttacker = attacker;
                                     attacker.blockedByThisBlocker.Add(blocker);
-                                    GameManager.Instance.NotifyCreatureBlocks(blocker, attacker);
                                     availableBlockers.Remove(blocker);
                                     Debug.Log($"AI blocks {attacker.cardName} with {blocker.cardName}");
                                 }
@@ -1073,6 +1072,14 @@ public class TurnSystem : MonoBehaviour
                     break;
 
                 case TurnPhase.ConfirmBlockers:
+                    foreach (var attacker in GameManager.Instance.currentAttackers)
+                    {
+                        foreach (var blocker in attacker.blockedByThisBlocker)
+                        {
+                            GameManager.Instance.NotifyCreatureBlocks(blocker, attacker);
+                        }
+                    }
+
                     if (!waitingForPlayerInput)
                     {
                         waitingForPlayerInput = true;


### PR DESCRIPTION
## Summary
- defer block-trigger events until blockers are confirmed
- remove early block notifications during block assignment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb62b11c8327ab508b3a04815b02