### PR TITLE
Add Touch Grass land-search sorcery

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -68,6 +68,7 @@ public class CardData
     public bool exileAllCreaturesFromGraveyards = false;
     public bool swapGraveyardAndLibrary = false;
     public bool revealUntilCreature = false;
+    public bool revealUntilLand = false;
     public bool returnRandomCreatureFromGraveyard = false;
     public bool returnRandomCheapCreatureToBattlefield = false;
     public int maxManaCostForReturn = 0;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2889,6 +2889,16 @@ public static class CardDatabase
                     eachPlayerGainLifeEqualToLands = true,
                     artwork = Resources.Load<Sprite>("Art/feast"),
                     });
+                Add(new CardData { //Touch Grass
+                    cardName = "Touch Grass",
+                    rarity = "Common",
+                    cardType = CardType.Sorcery,
+                    manaCost = 1,
+                    color = new List<string> { "Green" },
+                    revealUntilLand = true,
+                    artwork = Resources.Load<Sprite>("Art/touch_grass"),
+                    abilities = new List<CardAbility>(),
+                    });
                 Add(new CardData { //Rolling Energy
                     cardName = "Rolling Energy",
                     rarity = "Common",

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -58,6 +58,7 @@ public static class CardFactory
                 sorcery.manaToGainMax = data.manaToGainMax;
                 sorcery.swapGraveyardAndLibrary = data.swapGraveyardAndLibrary;
                 sorcery.revealUntilCreature = data.revealUntilCreature;
+                sorcery.revealUntilLand = data.revealUntilLand;
                 sorcery.returnRandomCreatureFromGraveyard = data.returnRandomCreatureFromGraveyard;
                 sorcery.returnRandomCheapCreatureToBattlefield = data.returnRandomCheapCreatureToBattlefield;
                 sorcery.maxManaCostForReturn = data.maxManaCostForReturn;

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -2145,6 +2145,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 rules += "Each player exchanges their graveyard with their library, then shuffles their deck.\n";
             if (sorcery.revealUntilCreature)
                 rules += "Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand, then shuffle.\n";
+            if (sorcery.revealUntilLand)
+                rules += "Reveal cards from the top of your library until you reveal a land card. Put that card into your hand, then shuffle.\n";
             if (sorcery.destroyTargetIfTypeMatches)
             {
                 string destroyType = sorcery.requiredTargetType switch

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1902,6 +1902,77 @@ public class GameManager : MonoBehaviour
         pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
     }
 
+    public IEnumerator RevealUntilLand(Player player)
+    {
+        List<Card> revealedNonLands = new List<Card>();
+        List<CardVisual> visuals = new List<CardVisual>();
+        Card landCard = null;
+        CardVisual landVisual = null;
+
+        int index = 0;
+        float spacing = 150f;
+
+        while (player.Deck.Count > 0)
+        {
+            Card top = player.Deck[0];
+            player.Deck.RemoveAt(0);
+
+            GameObject obj = Instantiate(cardPrefab, stackZone);
+            obj.transform.localPosition = new Vector3(index * spacing, 0f, 0f);
+            CardVisual visual = obj.GetComponent<CardVisual>();
+            CardData data = CardDatabase.GetCardData(top.cardName);
+            visual.Setup(top, this, data);
+            visual.isInStack = true;
+            visuals.Add(visual);
+
+            if (top is LandCard)
+            {
+                landCard = top;
+                landVisual = visual;
+                break;
+            }
+            else
+            {
+                revealedNonLands.Add(top);
+            }
+
+            index++;
+            yield return new WaitForSeconds(0.5f);
+        }
+
+        yield return new WaitForSeconds(0.5f);
+
+        if (landCard != null)
+        {
+            player.Hand.Add(landCard);
+            if (player == humanPlayer)
+            {
+                landVisual.transform.SetParent(playerHandArea, false);
+                landVisual.isInStack = false;
+                activeCardVisuals.Add(landVisual);
+            }
+            else
+            {
+                Destroy(landVisual.gameObject);
+                if (enemyHandText != null)
+                    enemyHandText.text = "Hand: " + player.Hand.Count;
+            }
+        }
+
+        foreach (var card in revealedNonLands)
+            player.Deck.Add(card);
+
+        foreach (var visual in visuals)
+        {
+            if (!(visual.linkedCard is LandCard))
+                Destroy(visual.gameObject);
+        }
+
+        ShuffleDeck(player);
+        UpdateUI();
+        pendingStackEffects = Mathf.Max(0, pendingStackEffects - 1);
+    }
+
     public void ReturnRandomInstantOrSorceryFromGraveyard(Player player)
     {
         var spells = player.Graveyard

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -18,6 +18,7 @@ public class SorceryCard : Card
     public bool exileAllCreaturesFromGraveyards = false;
     public bool swapGraveyardAndLibrary = false;
     public bool revealUntilCreature = false;
+    public bool revealUntilLand = false;
     public bool returnRandomCreatureFromGraveyard = false;
     public bool returnRandomCheapCreatureToBattlefield = false;
     public int maxManaCostForReturn = 0;
@@ -71,6 +72,13 @@ public class SorceryCard : Card
             {
                 GameManager.Instance.pendingStackEffects++;
                 GameManager.Instance.StartCoroutine(GameManager.Instance.RevealUntilCreature(caster));
+                didSomething = true;
+            }
+
+            if (revealUntilLand)
+            {
+                GameManager.Instance.pendingStackEffects++;
+                GameManager.Instance.StartCoroutine(GameManager.Instance.RevealUntilLand(caster));
                 didSomething = true;
             }
 


### PR DESCRIPTION
## Summary
- add Touch Grass, a 1-mana green sorcery that finds the first land on top of your library
- support reveal-until-land effects in card data and game logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eef8d0088327942b1dd9fdfc7205