### PR TITLE
Ensure revived creatures respect enters tapped

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -2101,10 +2101,13 @@ public class GameManager : MonoBehaviour
         player.Battlefield.Add(creature);
 
         creature.hasSummoningSickness = true;
-        if (IsAllPermanentsEnterTappedActive())
+        if (creature.entersTapped || IsAllPermanentsEnterTappedActive())
         {
             creature.isTapped = true;
-            Debug.Log($"{creature.cardName} enters tapped from graveyard due to global effect.");
+            Debug.Log($"{creature.cardName} enters tapped from graveyard" +
+                      (IsAllPermanentsEnterTappedActive() && !creature.entersTapped ?
+                       " due to global effect" :
+                       "") + ".");
         }
 
         GameObject obj = Instantiate(cardPrefab, player == humanPlayer ? playerBattlefieldArea : aiBattlefieldArea);


### PR DESCRIPTION
## Summary
- Ensure creatures returned from the graveyard enter tapped if they inherently do or a global effect requires it

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72ae788508327b4f033e67ad493ac