### PR TITLE
Fix stalled turn progression when banner remains active

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -1193,7 +1193,19 @@ public class TurnSystem : MonoBehaviour
 
         private IEnumerator WaitForBannerAndStart()
             {
-                yield return new WaitWhile(() => turnBanner.activeSelf);
+                // Previously this coroutine waited until the banner was manually
+                // hidden somewhere else. If that never happened, the coroutine
+                // would yield forever and the turn would never progress,
+                // effectively preventing the player from ending their turn.
+
+                // Show the banner for a short, fixed duration then hide it
+                // ourselves to ensure the game always advances to the next
+                // phase.
+                yield return new WaitForSeconds(1f);
+
+                if (turnBanner != null)
+                    turnBanner.SetActive(false);
+
                 AdvancePhase();
             }
 


### PR DESCRIPTION
## Summary
- Prevent turn banner coroutine from waiting forever
- Automatically hide the banner after a short delay so the turn advances

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e12aca4832e9bd655b22b398dc8