### PR TITLE
Add artist metadata to cards and display on visuals

### DIFF
--- a/Assets/Resources/Prefab/CardPrefab.prefab
+++ b/Assets/Resources/Prefab/CardPrefab.prefab
@@ -1633,6 +1633,7 @@ MonoBehaviour:
   statsText: {fileID: 6757367444350756674}
   keywordText: {fileID: 1868721622052657023}
   cardTypeText: {fileID: 7949847088018398147}
+  artistText: {fileID: 5808068336578498604}
   counterContainer: {fileID: 4710456736074502014}
   counterText: {fileID: 853636567053323019}
   counterImage: {fileID: 7194320920966003589}

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -27,6 +27,9 @@ public class Card
     public string rulesText;
     public string flavorText;
 
+    // Artist credited for the card's artwork
+    public string artist;
+
     public int plagueAmount;
     public int manaToGain;
     public int lifeToGain;

--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -20,6 +20,9 @@ public class CardData
     public string rulesText;
     public string flavorText;
 
+    // Name of the artist who illustrated the card
+    public string artist;
+
     public bool entersTapped = false;
     public bool isToken = false;
     public bool destroyTargetIfTypeMatches = false;

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -17,7 +17,8 @@ public static class CardDatabase
                 manaCost = 0,
                 color = new List<string> { "White" },
                 cardType = CardType.Land,
-                artwork = Resources.Load<Sprite>("Art/plains")
+                artwork = Resources.Load<Sprite>("Art/plains"),
+                artist = "Unknown"
             });
             Add(new CardData //Island
             {
@@ -26,7 +27,8 @@ public static class CardDatabase
                 manaCost = 0,
                 color = new List<string> { "Blue" },
                 cardType = CardType.Land,
-                artwork = Resources.Load<Sprite>("Art/island")
+                artwork = Resources.Load<Sprite>("Art/island"),
+                artist = "Unknown"
             });
             Add(new CardData //Swamp
             {
@@ -35,7 +37,8 @@ public static class CardDatabase
                 manaCost = 0,
                 color = new List<string> { "Black" },
                 cardType = CardType.Land,
-                artwork = Resources.Load<Sprite>("Art/swamp")
+                artwork = Resources.Load<Sprite>("Art/swamp"),
+                artist = "Unknown"
             });
             Add(new CardData //Mountain
             {
@@ -44,7 +47,8 @@ public static class CardDatabase
                 manaCost = 0,
                 color = new List<string> { "Red" },
                 cardType = CardType.Land,
-                artwork = Resources.Load<Sprite>("Art/mountain")
+                artwork = Resources.Load<Sprite>("Art/mountain"),
+                artist = "Unknown"
             });
             Add(new CardData //Forest
             {
@@ -53,7 +57,8 @@ public static class CardDatabase
                 manaCost = 0,
                 color = new List<string> { "Green" },
                 cardType = CardType.Land,
-                artwork = Resources.Load<Sprite>("Art/forest")
+                artwork = Resources.Load<Sprite>("Art/forest"),
+                artist = "Unknown"
             });
 
         // Creatures

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -161,6 +161,7 @@ public static class CardFactory
         newCard.abilities = new List<CardAbility>(data.abilities);
         newCard.rulesText = data.rulesText;
         newCard.flavorText = data.flavorText;
+        newCard.artist = data.artist;
         newCard.isToken = data.isToken;
         newCard.keywordBuff = data.keywordBuff;
 

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -55,6 +55,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
     public TMP_Text statsText;
     public TMP_Text keywordText;
     public TMP_Text cardTypeText;
+    public TMP_Text artistText;
 
     // UI elements showing +1/+1 or -1/-1 counters
     public GameObject counterContainer;
@@ -479,6 +480,19 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             SetCardBorder(data);
             UpdateLandIcon();
 
+            if (artistText != null)
+            {
+                if (data != null && !string.IsNullOrEmpty(data.artist) && !isInBattlefield)
+                {
+                    artistText.text = data.artist;
+                    artistText.gameObject.SetActive(true);
+                }
+                else
+                {
+                    artistText.gameObject.SetActive(false);
+                }
+            }
+
             // Display +1/+1 or -1/-1 counters if present
             if (counterContainer != null)
             {
@@ -753,6 +767,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             if (costText != null) costText.enabled = true;
             if (statsText != null) statsText.enabled = true;
             if (keywordText != null) keywordText.enabled = true;
+            if (artistText != null) artistText.enabled = true;
 
             var data = CardDatabase.GetCardData(linkedCard.cardName);
             SetTypeLine(data);
@@ -1804,6 +1819,11 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             sicknessText.text = "";
             keywordText.text = "";
             statsText.text = "";
+            if (artistText != null)
+            {
+                artistText.text = "";
+                artistText.gameObject.SetActive(false);
+            }
         }
 
     public void PrepareForGraveyard()
@@ -1819,6 +1839,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             if (costText != null) costText.enabled = true;
             if (statsText != null) statsText.enabled = true;
             if (keywordText != null) keywordText.enabled = true;
+            if (artistText != null) artistText.enabled = true;
 
             costBackground.SetActive(true);
             statsBackground.SetActive(true);
@@ -1893,6 +1914,7 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             if (statsText != null) statsText.enabled = true;
             if (keywordText != null) keywordText.enabled = true;
             if (cardRarity != null) cardRarity.enabled = true;
+            if (artistText != null) artistText.enabled = true;
 
             titleText.text = linkedCard.cardName;
             sicknessText.text = "";
@@ -1927,6 +1949,19 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             // Load card data
             CardData sourceData = CardDatabase.GetCardData(linkedCard.cardName);
             SetCardBorder(sourceData);
+
+            if (artistText != null)
+            {
+                if (sourceData != null && !string.IsNullOrEmpty(sourceData.artist))
+                {
+                    artistText.text = sourceData.artist;
+                    artistText.gameObject.SetActive(true);
+                }
+                else
+                {
+                    artistText.gameObject.SetActive(false);
+                }
+            }
 
             if (artImage != null && linkedCard.artwork != null)
                 artImage.sprite = linkedCard.artwork;


### PR DESCRIPTION
## Summary
- allow cards to store an artist credit and propagate it through CardFactory
- connect new artistText UI element in CardVisual and toggle its visibility
- sample basic lands now include placeholder artist names

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b06a3c22f0832ebc575093164f80fb