### PR TITLE
Group identical cards in deck editor

### DIFF
--- a/Assets/Scripts/DeckEditorManager.cs
+++ b/Assets/Scripts/DeckEditorManager.cs
@@ -213,25 +213,25 @@ public class DeckEditorManager : MonoBehaviour
 #endif
         }
 
-        var groupedBasics = new Dictionary<string, (CardData data, int count)>();
+        var groupedCards = new Dictionary<string, (CardData data, int count)>();
+        var order = new List<string>();
 
         foreach (var data in deck)
         {
-            if (CardData.IsBasicLand(data))
-            {
-                if (groupedBasics.TryGetValue(data.cardName, out var entry))
-                    groupedBasics[data.cardName] = (entry.data, entry.count + 1);
-                else
-                    groupedBasics[data.cardName] = (data, 1);
-            }
+            if (groupedCards.TryGetValue(data.cardName, out var entry))
+                groupedCards[data.cardName] = (entry.data, entry.count + 1);
             else
             {
-                SpawnCardVisual(prefab, data, 1);
+                groupedCards[data.cardName] = (data, 1);
+                order.Add(data.cardName);
             }
         }
 
-        foreach (var kvp in groupedBasics.Values)
-            SpawnCardVisual(prefab, kvp.data, kvp.count);
+        foreach (var name in order)
+        {
+            var entry = groupedCards[name];
+            SpawnCardVisual(prefab, entry.data, entry.count);
+        }
     }
 
     private void SpawnCardVisual(GameObject prefab, CardData data, int count)
@@ -266,21 +266,8 @@ public class DeckEditorManager : MonoBehaviour
 
         bool isFavourite = FavouriteCard != null && FavouriteCard.cardName == data.cardName;
 
-        if (CardData.IsBasicLand(data))
-        {
-            button.Decrement();
-            if (button.Count <= 0)
-            {
-                if (isFavourite)
-                {
-                    FavouriteCardManager star = FindObjectOfType<FavouriteCardManager>();
-                    if (star != null)
-                        star.ReturnToStart();
-                }
-                Destroy(button.gameObject);
-            }
-        }
-        else
+        button.Decrement();
+        if (button.Count <= 0)
         {
             if (isFavourite)
             {
@@ -320,27 +307,20 @@ public class DeckEditorManager : MonoBehaviour
 
         deck.Add(data);
 
-        if (CardData.IsBasicLand(data))
+        DeckEditorCardButton existing = null;
+        foreach (Transform child in cardContainer)
         {
-            DeckEditorCardButton existing = null;
-            foreach (Transform child in cardContainer)
+            var handler = child.GetComponent<DeckEditorCardButton>();
+            if (handler != null && handler.Data.cardName == data.cardName)
             {
-                var handler = child.GetComponent<DeckEditorCardButton>();
-                if (handler != null && handler.Data.cardName == data.cardName)
-                {
-                    existing = handler;
-                    break;
-                }
+                existing = handler;
+                break;
             }
+        }
 
-            if (existing != null)
-            {
-                existing.Increment();
-            }
-            else
-            {
-                SpawnCardVisual(prefab, data, 1);
-            }
+        if (existing != null)
+        {
+            existing.Increment();
         }
         else
         {

--- a/Assets/Scripts/DeckViewer.cs
+++ b/Assets/Scripts/DeckViewer.cs
@@ -44,25 +44,25 @@ public class DeckViewer : MonoBehaviour
             prefab = Resources.Load<GameObject>("Prefab/CardPrefab");
 #endif
 
-        var groupedBasics = new Dictionary<string, (CardData data, int count)>();
+        var groupedCards = new Dictionary<string, (CardData data, int count)>();
+        var order = new List<string>();
 
         foreach (var data in DeckHolder.SelectedDeck)
         {
-            if (CardData.IsBasicLand(data))
-            {
-                if (groupedBasics.TryGetValue(data.cardName, out var entry))
-                    groupedBasics[data.cardName] = (entry.data, entry.count + 1);
-                else
-                    groupedBasics[data.cardName] = (data, 1);
-            }
+            if (groupedCards.TryGetValue(data.cardName, out var entry))
+                groupedCards[data.cardName] = (entry.data, entry.count + 1);
             else
             {
-                Spawn(prefab, container, data, 1);
+                groupedCards[data.cardName] = (data, 1);
+                order.Add(data.cardName);
             }
         }
 
-        foreach (var kvp in groupedBasics.Values)
-            Spawn(prefab, container, kvp.data, kvp.count);
+        foreach (var name in order)
+        {
+            var entry = groupedCards[name];
+            Spawn(prefab, container, entry.data, entry.count);
+        }
     }
 
     private static void Spawn(GameObject prefab, Transform container, CardData data, int count)


### PR DESCRIPTION
## Summary
- Aggregate duplicate cards in deck viewer so each card type appears once with a count.
- Extend deck editor logic to group duplicates, decrementing and incrementing counts instead of spawning separate entries.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a2b8296c832eb85c2a80719cb6a4