### PR TITLE
Fix spacebar input to always advance phase

### DIFF
--- a/Assets/Scripts/TurnSystem.cs
+++ b/Assets/Scripts/TurnSystem.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System.Linq;
+using UnityEngine.EventSystems;
 
 public class TurnSystem : MonoBehaviour
 {
@@ -116,14 +117,32 @@ public class TurnSystem : MonoBehaviour
             // Handle spacebar shortcut
             if (Input.GetKeyDown(KeyCode.Space))
             {
+                // Prevent UI buttons from also processing the spacebar press
+                if (EventSystem.current != null)
+                    EventSystem.current.SetSelectedGameObject(null);
+
                 if (currentPlayer == PlayerType.Human &&
                     waitingForPlayerInput &&
-                    (!GameManager.Instance.IsStackActive() || GameManager.Instance.isTargetingMode) &&
                     !GameManager.Instance.graveyardViewActive &&
-                    currentPhase != TurnPhase.ConfirmAttackers &&
-                    currentPhase != TurnPhase.ChooseAttackers)
+                    (!GameManager.Instance.IsStackActive() || GameManager.Instance.isTargetingMode))
                 {
-                    NextPhaseButton();
+                    switch (currentPhase)
+                    {
+                        case TurnPhase.ConfirmAttackers:
+                            ConfirmAttackers();
+                            break;
+                        case TurnPhase.ChooseAttackers:
+                            waitingForPlayerInput = false;
+                            HideAllConfirmButtons();
+                            AdvancePhase();
+                            break;
+                        case TurnPhase.ConfirmBlockers:
+                            ConfirmBlockers();
+                            break;
+                        default:
+                            NextPhaseButton();
+                            break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Ensure pressing spacebar always advances to the next turn phase
- Clear selected UI elements so spacebar doesn't activate other buttons
- Automatically confirm or skip combat steps when spacebar is pressed

## Testing
- `dotnet build ReMagicPro.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9935144832eacd5302f44330b09