### PR TITLE
Add Rolling Despair sorcery

### DIFF
--- a/Assets/Scripts/CardData.cs
+++ b/Assets/Scripts/CardData.cs
@@ -89,6 +89,8 @@ public class CardData
     public KeywordAbility keywordToGrant = KeywordAbility.None;
     public bool addXPlusOneCounters = false;
     public bool addXMinusOneCounters = false;
+    public int creaturesToSacrificeEachPlayerMin = 0;
+    public int creaturesToSacrificeEachPlayerMax = 0;
 
     public SorceryCard.PermanentTypeToDestroy typeOfPermanentToDestroyAll = SorceryCard.PermanentTypeToDestroy.None;
 

--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -2886,6 +2886,19 @@ public static class CardDatabase
                         maxManaCostForReturn = 1,
                         artwork = Resources.Load<Sprite>("Art/pact_of_bones")
                     });
+                Add(new CardData //Rolling Despair
+                    {
+                        cardName = "Rolling Despair",
+                        artist = "Sora AI",
+                        rarity = "Uncommon",
+                        cardType = CardType.Sorcery,
+                        manaCost = 5,
+                        color = new List<string> { "Black", "Black" },
+                        rulesText = "Each player rolls a six-sided die and sacrifices that many creatures.",
+                        creaturesToSacrificeEachPlayerMin = 1,
+                        creaturesToSacrificeEachPlayerMax = 6,
+                        artwork = Resources.Load<Sprite>("Art/rolling_despair")
+                    });
             // RED
                 Add(new CardData //To dig a hole
                         {

--- a/Assets/Scripts/CardFactory.cs
+++ b/Assets/Scripts/CardFactory.cs
@@ -81,6 +81,8 @@ public static class CardFactory
                 sorcery.buffToughness = data.toughnessBuff;
                 sorcery.addXPlusOneCounters = data.addXPlusOneCounters;
                 sorcery.addXMinusOneCounters = data.addXMinusOneCounters;
+                sorcery.creaturesToSacrificeEachPlayerMin = data.creaturesToSacrificeEachPlayerMin;
+                sorcery.creaturesToSacrificeEachPlayerMax = data.creaturesToSacrificeEachPlayerMax;
                 newCard = sorcery;
                 break;
             case CardType.Artifact:

--- a/Assets/Scripts/SorceryCard.cs
+++ b/Assets/Scripts/SorceryCard.cs
@@ -12,6 +12,8 @@ public class SorceryCard : Card
     public int cardsToDiscardorDraw = 0;
     public bool drawIfOpponentCantDiscard = true;
     public int damageToEachCreatureAndPlayer = 0;
+    public int creaturesToSacrificeEachPlayerMin = 0;
+    public int creaturesToSacrificeEachPlayerMax = 0;
     public int manaToGainMin = 0;
     public int manaToGainMax = 0;
     public bool eachPlayerGainLifeEqualToLands = false;
@@ -195,16 +197,45 @@ public class SorceryCard : Card
                         {
                             Debug.Log($"{opponent} has no cards to discard.");
                         }
-                    }
-
-                    if (!opponentDiscarded && drawIfOpponentCantDiscard)
-                    {
-                        GameManager.Instance.DrawCard(caster);
-                        Debug.Log($"{caster} draws a card because opponent had nothing to discard.");
-                    }
-
-                    didSomething = true;
                 }
+
+                if (!opponentDiscarded && drawIfOpponentCantDiscard)
+                {
+                    GameManager.Instance.DrawCard(caster);
+                    Debug.Log($"{caster} draws a card because opponent had nothing to discard.");
+                }
+
+                didSomething = true;
+            }
+            if (creaturesToSacrificeEachPlayerMax > 0)
+            {
+                List<(Card card, Player owner)> sacrifices = new List<(Card, Player)>();
+                foreach (var player in new[] { GameManager.Instance.humanPlayer, GameManager.Instance.aiPlayer })
+                {
+                    int amount = (creaturesToSacrificeEachPlayerMin == creaturesToSacrificeEachPlayerMax)
+                        ? creaturesToSacrificeEachPlayerMin
+                        : Random.Range(creaturesToSacrificeEachPlayerMin, creaturesToSacrificeEachPlayerMax + 1);
+
+                    var creatures = player.Battlefield.OfType<CreatureCard>().ToList();
+                    if (amount > creatures.Count)
+                        amount = creatures.Count;
+
+                    for (int i = 0; i < amount; i++)
+                    {
+                        var chosen = creatures[Random.Range(0, creatures.Count)];
+                        creatures.Remove(chosen);
+                        sacrifices.Add((chosen, player));
+                    }
+                }
+
+                foreach (var (card, owner) in sacrifices)
+                {
+                    GameManager.Instance.SendToGraveyard(card, owner);
+                }
+
+                if (sacrifices.Count > 0)
+                    didSomething = true;
+            }
             if (eachPlayerGainLifeEqualToLands)
                 {
                     Player human = GameManager.Instance.humanPlayer;


### PR DESCRIPTION
## Summary
- allow sorcery cards to make each player sacrifice a random number of creatures
- wire new sacrifice fields through card data and factory
- add the uncommon black sorcery **Rolling Despair** to the card database

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eb184974832eb6410cb7ba758d04