### PR TITLE
Color ability mana text and enforce colored activation costs

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -54,6 +54,36 @@ public class Card
     public List<ActivatedAbility> activatedAbilities = new List<ActivatedAbility>();
     public List<KeywordAbility> keywordAbilities = new List<KeywordAbility>();
 
+    public string GetPrimaryManaColor()
+    {
+        if (color == null || color.Count == 0)
+            return "Colorless";
+
+        string firstColored = color.FirstOrDefault(c => c != "Artifact");
+        if (string.IsNullOrEmpty(firstColored))
+            firstColored = color.FirstOrDefault();
+
+        return ManaColorUtility.NormalizeColor(firstColored);
+    }
+
+    public virtual string GetActivationColor()
+    {
+        return GetPrimaryManaColor();
+    }
+
+    protected string FormatColoredManaNumber(int amount, string colorName)
+    {
+        string normalized = ManaColorUtility.NormalizeColor(colorName);
+        string hex = ManaColorUtility.GetHexCode(normalized);
+        return $"<color={hex}>{amount}</color>";
+    }
+
+    protected string FormatColoredManaWithLabel(int amount, string colorName)
+    {
+        string normalized = ManaColorUtility.NormalizeColor(colorName);
+        return $"{FormatColoredManaNumber(amount, normalized)} {ManaColorUtility.GetDisplayName(normalized)} mana";
+    }
+
     public virtual void Play(Player player)
         {
             if (entersTapped)
@@ -177,25 +207,25 @@ public class Card
                             switch (activated)
                             {
                                 case ActivatedAbility.TapForMana:
-                                    lines.Add("Tap: Add 1 mana.");
+                                    lines.Add($"Tap: Add {FormatColoredManaWithLabel(1, creature.GetActivationColor())}.");
                                     break;
                                 case ActivatedAbility.TapToLoseLife:
                                     lines.Add($"Tap: Your opponent loses {creature.tapLifeLossAmount} life.");
                                     break;
                                 case ActivatedAbility.TapToCreateToken:
-                                    lines.Add($"{creature.manaToPayToActivate}TAP: Create a {tokenToCreate} token.");
+                                    lines.Add($"{FormatColoredManaNumber(creature.manaToPayToActivate, creature.GetActivationColor())}TAP: Create a {tokenToCreate} token.");
                                     break;
                                 case ActivatedAbility.PayToGainAbility:
-                                    lines.Add($"{creature.manaToPayToActivate}: Gains {creature.abilityToGain} until end of turn.");
+                                    lines.Add($"{FormatColoredManaNumber(creature.manaToPayToActivate, creature.GetActivationColor())}: Gains {creature.abilityToGain} until end of turn.");
                                     break;
                                 case ActivatedAbility.PayToBuffSelf:
-                                    lines.Add($"{creature.manaToPayToActivate}: +1/+0 until end of turn.");
+                                    lines.Add($"{FormatColoredManaNumber(creature.manaToPayToActivate, creature.GetActivationColor())}: +1/+0 until end of turn.");
                                     break;
                                 case ActivatedAbility.ReturnSelfFromGraveyard:
-                                    lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to the battlefield.");
+                                    lines.Add($"{FormatColoredManaNumber(creature.manaToPayToActivate, creature.GetActivationColor())}: Return this card from your graveyard to the battlefield.");
                                     break;
                                 case ActivatedAbility.ReturnSelfFromGraveyardToHand:
-                                    lines.Add($"{creature.manaToPayToActivate}: Return this card from your graveyard to your hand.");
+                                    lines.Add($"{FormatColoredManaNumber(creature.manaToPayToActivate, creature.GetActivationColor())}: Return this card from your graveyard to your hand.");
                                     break;
                             }
                         }
@@ -219,20 +249,20 @@ public class Card
                         switch (activated)
                         {
                             case ActivatedAbility.TapForMana:
-                                lines.Add("Tap: Add 1 mana.");
+                                lines.Add($"Tap: Add {FormatColoredManaWithLabel(1, GetActivationColor())}.");
                                 break;
                             case ActivatedAbility.TapToGainLife:
                                 lines.Add("Tap: Gain 1 life.");
                                 //lines.Add($"Tap: Gain {plagueAmount} life.");
                                 break;
                             case ActivatedAbility.TapAndSacrificeForMana:
-                                lines.Add("Tap, sacrifice: Add 1 mana.");
+                                lines.Add($"Tap, sacrifice: Add {FormatColoredManaWithLabel(1, GetActivationColor())}.");
                                 break;
                             case ActivatedAbility.TapToPlague:
                                 lines.Add($"Tap: Each player loses {plagueAmount} life.");
                                 break;
                             case ActivatedAbility.SacrificeForMana:
-                                lines.Add($"{manaToPayToActivate}TAP, sacrifice: Add {manaToGain}.");
+                                lines.Add($"{FormatColoredManaNumber(manaToPayToActivate, GetActivationColor())}TAP, sacrifice: Add {FormatColoredManaWithLabel(manaToGain, GetActivationColor())}.");
                                 break;
                             case ActivatedAbility.SacrificeForLife:
                                 lines.Add($"{manaToPayToActivate}TAP, sacrifice: Gain {lifeToGain} life.");
@@ -247,10 +277,10 @@ public class Card
                                 lines.Add($"{manaToPayToActivate}TAP, sacrifice: Target creature gets +{buffPower}/+{buffToughness} until end of turn.");
                                 break;
                             case ActivatedAbility.TapToPlayRandomPotion:
-                                lines.Add($"{manaToPayToActivate}TAP: Search your library for a random Potion and put it onto the battlefield, then shuffle.");
+                                lines.Add($"{FormatColoredManaNumber(manaToPayToActivate, GetActivationColor())}TAP: Search your library for a random Potion and put it onto the battlefield, then shuffle.");
                                 break;
                             case ActivatedAbility.Equip:
-                                lines.Add($"Equip {manaToPayToActivate}");
+                                lines.Add($"Equip {FormatColoredManaNumber(manaToPayToActivate, GetActivationColor())}");
                                 break;
                         }
                     }

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -885,28 +885,43 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 {
                     Player player = GameManager.Instance.humanPlayer;
                     int cost = graveCreature.manaToPayToActivate;
+                    string abilityColor = graveCreature.GetActivationColor();
                     if (graveCreature.activatedAbilities.Contains(ActivatedAbility.ReturnSelfFromGraveyard))
                     {
-                        if (player.ColoredMana.Total() >= cost)
+                        if (player.ColoredMana.HasEnough(abilityColor, cost))
                         {
-                            player.ColoredMana.SpendGeneric(cost);
+                            if (!player.ColoredMana.SpendColor(abilityColor, cost))
+                            {
+                                Debug.LogWarning("Graveyard activation failed to spend mana despite HasEnough check.");
+                                return;
+                            }
                             GameManager.Instance.QueueCreatureActivatedAbility(graveCreature, ActivatedAbility.ReturnSelfFromGraveyard, player);
                         }
                         else
                         {
-                            Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                            if (ManaColorUtility.NormalizeColor(abilityColor) == "Colorless")
+                                Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                            else
+                                Debug.Log($"Not enough {ManaColorUtility.GetDisplayName(abilityColor)} mana to return {graveCreature.cardName} from the graveyard.");
                         }
                     }
                     else if (graveCreature.activatedAbilities.Contains(ActivatedAbility.ReturnSelfFromGraveyardToHand))
                     {
-                        if (player.ColoredMana.Total() >= cost)
+                        if (player.ColoredMana.HasEnough(abilityColor, cost))
                         {
-                            player.ColoredMana.SpendGeneric(cost);
+                            if (!player.ColoredMana.SpendColor(abilityColor, cost))
+                            {
+                                Debug.LogWarning("Graveyard activation failed to spend mana despite HasEnough check.");
+                                return;
+                            }
                             GameManager.Instance.QueueCreatureActivatedAbility(graveCreature, ActivatedAbility.ReturnSelfFromGraveyardToHand, player);
                         }
                         else
                         {
-                            Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                            if (ManaColorUtility.NormalizeColor(abilityColor) == "Colorless")
+                                Debug.Log($"Not enough mana to return {graveCreature.cardName} from the graveyard.");
+                            else
+                                Debug.Log($"Not enough {ManaColorUtility.GetDisplayName(abilityColor)} mana to return {graveCreature.cardName} from the graveyard.");
                         }
                     }
                 }
@@ -1114,20 +1129,8 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
                 SoundManager.Instance.PlaySound(SoundManager.Instance.tap_for_mana);
                 linkedCard.isTapped = true;
 
-                string color = linkedCard.PrimaryColor;
-
-                switch (color)
-                {
-                    case "White": GameManager.Instance.humanPlayer.ColoredMana.White++; break;
-                    case "Blue": GameManager.Instance.humanPlayer.ColoredMana.Blue++; break;
-                    case "Black": GameManager.Instance.humanPlayer.ColoredMana.Black++; break;
-                    case "Red": GameManager.Instance.humanPlayer.ColoredMana.Red++; break;
-                    case "Green": GameManager.Instance.humanPlayer.ColoredMana.Green++; break;
-                    default:
-                        GameManager.Instance.humanPlayer.ColoredMana.Colorless++;
-                        Debug.LogWarning($"{linkedCard.cardName} has no valid color for mana — added colorless instead.");
-                        break;
-                }
+                string color = linkedCard.GetActivationColor();
+                GameManager.Instance.humanPlayer.ColoredMana.AddMana(color);
 
                 GameManager.Instance.UpdateUI();
                 UpdateVisual();
@@ -1147,41 +1150,18 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             {
                 Player player = GameManager.Instance.humanPlayer;
                 int cost = abilityCreature.manaToPayToActivate;
-                string cardColor = abilityCreature.PrimaryColor;
+                string abilityColor = abilityCreature.GetActivationColor();
 
-                // Colored ability: must pay using that color (plus generic if cost > 1)
-                if (!string.IsNullOrEmpty(cardColor) && cardColor != "Artifact")
+                if (player.ColoredMana.HasEnough(abilityColor, cost))
                 {
-                    int available = cardColor switch
-                    {
-                        "White" => player.ColoredMana.White,
-                        "Blue" => player.ColoredMana.Blue,
-                        "Black" => player.ColoredMana.Black,
-                        "Red" => player.ColoredMana.Red,
-                        "Green" => player.ColoredMana.Green,
-                        _ => 0
-                    };
-
-                    int remaining = cost - 1;
-                    if (available >= 1 && player.ColoredMana.Total() - available >= remaining)
-                    {
-                        GameManager.Instance.QueueCreatureActivatedAbility(abilityCreature, ActivatedAbility.PayToGainAbility, player);
-                    }
-                    else
-                    {
-                        Debug.Log($"Not enough {cardColor} + generic mana to activate {abilityCreature.cardName}'s ability.");
-                    }
+                    GameManager.Instance.QueueCreatureActivatedAbility(abilityCreature, ActivatedAbility.PayToGainAbility, player);
                 }
-                else // Colorless/generic activation
+                else
                 {
-                    if (player.ColoredMana.Total() >= cost)
-                    {
-                        GameManager.Instance.QueueCreatureActivatedAbility(abilityCreature, ActivatedAbility.PayToGainAbility, player);
-                    }
+                    if (ManaColorUtility.NormalizeColor(abilityColor) == "Colorless")
+                        Debug.Log($"Not enough mana to activate {abilityCreature.cardName}'s ability.");
                     else
-                    {
-                        Debug.Log($"Not enough generic mana to activate {abilityCreature.cardName}'s ability.");
-                    }
+                        Debug.Log($"Not enough {ManaColorUtility.GetDisplayName(abilityColor)} mana to activate {abilityCreature.cardName}'s ability.");
                 }
                 return;
             }
@@ -1199,39 +1179,18 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             {
                 Player player = GameManager.Instance.humanPlayer;
                 int cost = pumpCreature.manaToPayToActivate;
-                string color = pumpCreature.PrimaryColor;
+                string color = pumpCreature.GetActivationColor();
 
-                if (!string.IsNullOrEmpty(color) && color != "Artifact")
+                if (player.ColoredMana.HasEnough(color, cost))
                 {
-                    int available = color switch
-                    {
-                        "White" => player.ColoredMana.White,
-                        "Blue" => player.ColoredMana.Blue,
-                        "Black" => player.ColoredMana.Black,
-                        "Red" => player.ColoredMana.Red,
-                        "Green" => player.ColoredMana.Green,
-                        _ => 0
-                    };
-
-                    if (available >= cost)
-                    {
-                        GameManager.Instance.QueueCreatureActivatedAbility(pumpCreature, ActivatedAbility.PayToBuffSelf, player);
-                    }
-                    else
-                    {
-                        Debug.Log($"Not enough {color} mana to activate {pumpCreature.cardName}'s ability.");
-                    }
+                    GameManager.Instance.QueueCreatureActivatedAbility(pumpCreature, ActivatedAbility.PayToBuffSelf, player);
                 }
                 else
                 {
-                    if (player.ColoredMana.Total() >= cost)
-                    {
-                        GameManager.Instance.QueueCreatureActivatedAbility(pumpCreature, ActivatedAbility.PayToBuffSelf, player);
-                    }
-                    else
-                    {
+                    if (ManaColorUtility.NormalizeColor(color) == "Colorless")
                         Debug.Log($"Not enough mana to activate {pumpCreature.cardName}'s ability.");
-                    }
+                    else
+                        Debug.Log($"Not enough {ManaColorUtility.GetDisplayName(color)} mana to activate {pumpCreature.cardName}'s ability.");
                 }
 
                 return;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -2178,12 +2178,13 @@ public class GameManager : MonoBehaviour
 
     public void TapCardForMana(CreatureCard creature)
     {
-        if (!creature.isTapped)
-        {
-            creature.isTapped = true;
-            humanPlayer.ColoredMana.Colorless++;
-            UpdateUI();
-        }
+        if (creature == null || creature.isTapped)
+            return;
+
+        creature.isTapped = true;
+        Player owner = GetOwnerOfCard(creature) ?? humanPlayer;
+        owner.ColoredMana.AddMana(creature.GetActivationColor());
+        UpdateUI();
     }
 
     public void TapToLoseLife(CreatureCard creature)
@@ -2241,27 +2242,21 @@ public class GameManager : MonoBehaviour
         }
 
         Player owner = GetOwnerOfCard(creature);
-        int remaining = creature.manaToPayToActivate;
+        int cost = creature.manaToPayToActivate;
+        string abilityColor = creature.GetActivationColor();
 
-        if (owner.ColoredMana.Total() >= remaining)
+        if (!owner.ColoredMana.SpendColor(abilityColor, cost))
         {
-            // Spend colorless first
-            int useColorless = Mathf.Min(owner.ColoredMana.Colorless, remaining);
-            owner.ColoredMana.Colorless -= useColorless;
-            remaining -= useColorless;
-
-            // Spend from WUBRG
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.White, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Blue, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Black, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Red, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Green, remaining);
-
-            if (remaining > 0)
+            if (ManaColorUtility.NormalizeColor(abilityColor) == "Colorless")
             {
-                Debug.LogWarning("PayToGainAbility: Not enough mana despite Total() check.");
-                return;
+                Debug.Log($"Not enough mana to activate {creature.cardName}'s ability.");
             }
+            else
+            {
+                Debug.Log($"Not enough {ManaColorUtility.GetDisplayName(abilityColor)} mana to activate {creature.cardName}'s ability.");
+            }
+            return;
+        }
 
             if (!creature.keywordAbilities.Contains(creature.abilityToGain))
                 creature.keywordAbilities.Add(creature.abilityToGain);
@@ -2279,36 +2274,26 @@ public class GameManager : MonoBehaviour
                 }
             }
             UpdateUI();
-        }
-        else
-        {
-            Debug.Log($"Not enough mana to activate {creature.cardName}'s ability.");
-            return;
-        }
     }
 
     public void PayToBuffSelf(CreatureCard creature)
     {
         Player owner = GetOwnerOfCard(creature);
-        int remaining = creature.manaToPayToActivate;
+        int cost = creature.manaToPayToActivate;
+        string abilityColor = creature.GetActivationColor();
 
-        if (owner.ColoredMana.Total() >= remaining)
+        if (!owner.ColoredMana.SpendColor(abilityColor, cost))
         {
-            int useColorless = Mathf.Min(owner.ColoredMana.Colorless, remaining);
-            owner.ColoredMana.Colorless -= useColorless;
-            remaining -= useColorless;
-
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.White, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Blue, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Black, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Red, remaining);
-            remaining -= Player.ManaPool.SpendFromPool(ref owner.ColoredMana.Green, remaining);
-
-            if (remaining > 0)
+            if (ManaColorUtility.NormalizeColor(abilityColor) == "Colorless")
             {
-                Debug.LogWarning("PayToBuffSelf: Not enough mana despite Total() check.");
-                return;
+                Debug.Log($"Not enough mana to activate {creature.cardName}'s ability.");
             }
+            else
+            {
+                Debug.Log($"Not enough {ManaColorUtility.GetDisplayName(abilityColor)} mana to activate {creature.cardName}'s ability.");
+            }
+            return;
+        }
 
             creature.AddTemporaryBuff(1, 0);
             var vis = FindCardVisual(creature);
@@ -2317,11 +2302,6 @@ public class GameManager : MonoBehaviour
 
             Debug.Log($"{creature.cardName} gets +1/+0 until end of turn.");
             UpdateUI();
-        }
-        else
-        {
-            Debug.Log($"Not enough mana to activate {creature.cardName}'s ability.");
-        }
     }
 
     public Player GetOwnerOfCard(Card card)

--- a/Assets/Scripts/ManaColorUtility.cs
+++ b/Assets/Scripts/ManaColorUtility.cs
@@ -1,0 +1,35 @@
+using System;
+
+public static class ManaColorUtility
+{
+    public static string NormalizeColor(string color)
+    {
+        if (string.IsNullOrEmpty(color))
+            return "Colorless";
+
+        return color switch
+        {
+            "Artifact" => "Colorless",
+            "None" => "Colorless",
+            _ => color
+        };
+    }
+
+    public static string GetHexCode(string color)
+    {
+        return NormalizeColor(color) switch
+        {
+            "White" => "#FFD966",   // Yellow
+            "Blue" => "#0096FF",    // Azure
+            "Black" => "#8A2BE2",   // Purple
+            "Red" => "#FF8C00",     // Orange
+            "Green" => "#228B22",   // Green
+            _ => "#B0B0B0"            // Grey for colorless
+        };
+    }
+
+    public static string GetDisplayName(string color)
+    {
+        return NormalizeColor(color).ToLowerInvariant();
+    }
+}

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -37,6 +37,72 @@ public class Player
                 return White + Blue + Black + Red + Green + Colorless;
             }
 
+        public int GetColorAmount(string color)
+        {
+            string normalized = ManaColorUtility.NormalizeColor(color);
+            return normalized switch
+            {
+                "White" => White,
+                "Blue" => Blue,
+                "Black" => Black,
+                "Red" => Red,
+                "Green" => Green,
+                "Colorless" => Colorless,
+                _ => 0
+            };
+        }
+
+        public bool HasEnough(string color, int amount)
+        {
+            string normalized = ManaColorUtility.NormalizeColor(color);
+            if (normalized == "Colorless")
+                return Total() >= amount;
+
+            return GetColorAmount(normalized) >= amount;
+        }
+
+        public bool SpendColor(string color, int amount)
+        {
+            string normalized = ManaColorUtility.NormalizeColor(color);
+
+            if (normalized == "Colorless")
+            {
+                if (Total() < amount)
+                    return false;
+
+                SpendGeneric(amount);
+                return true;
+            }
+
+            if (GetColorAmount(normalized) < amount)
+                return false;
+
+            switch (normalized)
+            {
+                case "White": White -= amount; break;
+                case "Blue": Blue -= amount; break;
+                case "Black": Black -= amount; break;
+                case "Red": Red -= amount; break;
+                case "Green": Green -= amount; break;
+            }
+
+            return true;
+        }
+
+        public void AddMana(string color, int amount = 1)
+        {
+            string normalized = ManaColorUtility.NormalizeColor(color);
+            switch (normalized)
+            {
+                case "White": White += amount; break;
+                case "Blue": Blue += amount; break;
+                case "Black": Black += amount; break;
+                case "Red": Red += amount; break;
+                case "Green": Green += amount; break;
+                default: Colorless += amount; break;
+            }
+        }
+
         public bool CanPay(Dictionary<string, int> cost)
             {
                 int genericRequired = cost.ContainsKey("Colorless") ? cost["Colorless"] : 0;


### PR DESCRIPTION
## Summary
- add a mana color utility to centralize normalized names and UI hex codes
- colorize activated ability text so mana costs and production numbers match their color identity
- require colored mana when activating creature abilities, updating mana pool helpers, game logic, and UI checks

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd5bbd370c832e87d7ecfa90ada838