### PR TITLE
Clarify Untamed Unicorn text and controller handling

### DIFF
--- a/Assets/Scripts/CardDatabase.cs
+++ b/Assets/Scripts/CardDatabase.cs
@@ -359,7 +359,7 @@ public static class CardDatabase
                     power = 0,
                     toughness = 0,
                     subtypes = new List<string> { "Horse" },
-                    rulesText = "This creature has power and toughness equal to the number of Plains you control.",
+                    rulesText = "Untamed Unicorn's power and toughness are each equal to the number of Plains you control. (It only counts Plains you control, and if it has 0 toughness it dies.)",
                     keywordAbilities = new List<KeywordAbility>
                     {
                         KeywordAbility.Vigilance,
@@ -381,6 +381,7 @@ public static class CardDatabase
                                     creature.baseToughness = plains;
                                     creature.RecalculateStats();
                                     GameManager.Instance.UpdateUI();
+                                    GameManager.Instance.CheckDeaths(owner);
                                 }
                             }
                         },
@@ -397,6 +398,7 @@ public static class CardDatabase
                                     creature.baseToughness = plains;
                                     creature.RecalculateStats();
                                     GameManager.Instance.UpdateUI();
+                                    GameManager.Instance.CheckDeaths(owner);
                                 }
                             }
                         },
@@ -413,6 +415,7 @@ public static class CardDatabase
                                     creature.baseToughness = plains;
                                     creature.RecalculateStats();
                                     GameManager.Instance.UpdateUI();
+                                    GameManager.Instance.CheckDeaths(owner);
                                 }
                             }
                         }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -2364,7 +2364,20 @@ public class GameManager : MonoBehaviour
             visual.UpdateVisual();
         }
 
+        HandleControlChange(card, newController);
         UpdateUI();
+    }
+
+    private void HandleControlChange(Card card, Player newController)
+    {
+        if (card is CreatureCard creature && card.cardName == "Untamed Unicorn")
+        {
+            int plains = newController.Battlefield.Count(c => c.cardName == "Plains");
+            creature.basePower = plains;
+            creature.baseToughness = plains;
+            creature.RecalculateStats();
+            CheckDeaths(newController);
+        }
     }
 
     public void UpdateUI()


### PR DESCRIPTION
## Summary
- clarify Untamed Unicorn's rules text so it only counts Plains you control and explains lethal zero toughness
- trigger death checks after its Plains-based stat recalculations to ensure it dies when toughness falls to 0
- update controller change handling so Untamed Unicorn adjusts to the new controller's Plains count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5efa4924832e82df9a565ba4cbab