### PR TITLE
Improve mana color highlight visibility

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -75,7 +75,17 @@ public class Card
     {
         string normalized = ManaColorUtility.NormalizeColor(colorName);
         string hex = ManaColorUtility.GetHexCode(normalized);
-        return $"<color={hex}>{amount}</color>";
+        string textColorHex = "#000000";
+
+        if (ColorUtility.TryParseHtmlString(hex, out Color color))
+        {
+            float luminance = 0.2126f * color.r + 0.7152f * color.g + 0.0722f * color.b;
+            textColorHex = luminance < 0.5f ? "#FFFFFF" : "#000000";
+        }
+
+        string markHex = hex.Length == 7 ? hex + "FF" : hex;
+
+        return $"<mark={markHex}><color={textColorHex}>{amount}</color></mark>";
     }
 
     protected string FormatColoredManaWithLabel(int amount, string colorName)


### PR DESCRIPTION
## Summary
- update mana formatting so ability costs use a colored background with contrasting text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e0ee5314832eb2f26806086861f8