### PR TITLE
Update mana ability text formatting

### DIFF
--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -73,25 +73,12 @@ public class Card
 
     protected string FormatColoredManaNumber(int amount, string colorName)
     {
-        string normalized = ManaColorUtility.NormalizeColor(colorName);
-        string hex = ManaColorUtility.GetHexCode(normalized);
-        string textColorHex = "#000000";
-
-        if (ColorUtility.TryParseHtmlString(hex, out Color color))
-        {
-            float luminance = 0.2126f * color.r + 0.7152f * color.g + 0.0722f * color.b;
-            textColorHex = luminance < 0.5f ? "#FFFFFF" : "#000000";
-        }
-
-        string markHex = hex.Length == 7 ? hex + "FF" : hex;
-
-        return $"<mark={markHex}><color={textColorHex}>{amount}</color></mark>";
+        return ManaColorUtility.FormatColoredManaNumber(amount, colorName);
     }
 
     protected string FormatColoredManaWithLabel(int amount, string colorName)
     {
-        string normalized = ManaColorUtility.NormalizeColor(colorName);
-        return $"{FormatColoredManaNumber(amount, normalized)} {ManaColorUtility.GetDisplayName(normalized)} mana";
+        return ManaColorUtility.FormatColoredManaNumber(amount, colorName);
     }
 
     public virtual void Play(Player player)

--- a/Assets/Scripts/CardVisual.cs
+++ b/Assets/Scripts/CardVisual.cs
@@ -2087,15 +2087,18 @@ public class CardVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
             {
                 int min = sorcery.manaToGainMin;
                 int max = sorcery.manaToGainMax;
+                string manaColor = sorcery.PrimaryColor;
 
-                string colorName = sorcery.PrimaryColor.ToLower();
                 if (min == max)
                 {
-                    rules += $"Add {min} {colorName} mana.\n";
+                    string amountText = ManaColorUtility.FormatColoredManaNumber(min, manaColor);
+                    rules += $"Add {amountText}.\n";
                 }
                 else
                 {
-                    rules += $"Add {min}-{max} {colorName} mana.\n";
+                    string minText = ManaColorUtility.FormatColoredManaNumber(min, manaColor);
+                    string maxText = ManaColorUtility.FormatColoredManaNumber(max, manaColor);
+                    rules += $"Add {minText}-{maxText}.\n";
                 }
             }
             if (sorcery.cardsToDiscardorDraw > 0)

--- a/Assets/Scripts/ManaColorUtility.cs
+++ b/Assets/Scripts/ManaColorUtility.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 public static class ManaColorUtility
 {
@@ -31,5 +32,21 @@ public static class ManaColorUtility
     public static string GetDisplayName(string color)
     {
         return NormalizeColor(color).ToLowerInvariant();
+    }
+
+    public static string FormatColoredManaNumber(int amount, string colorName)
+    {
+        string normalized = NormalizeColor(colorName);
+        string hex = GetHexCode(normalized);
+        string markHex = hex.Length == 7 ? hex + "FF" : hex;
+
+        string textColorHex = "#000000";
+        if (ColorUtility.TryParseHtmlString(hex, out Color color))
+        {
+            float luminance = 0.2126f * color.r + 0.7152f * color.g + 0.0722f * color.b;
+            textColorHex = luminance < 0.5f ? "#FFFFFF" : "#000000";
+        }
+
+        return $"<mark={markHex}><color={textColorHex}>{amount}</color></mark>";
     }
 }


### PR DESCRIPTION
## Summary
- add shared helper in ManaColorUtility to render mana amounts with colored backgrounds
- update card mana ability text to show only the numeric amount on the colored background
- adjust sorcery rule text to match the new mana formatting without color names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e3450bfc832e88579149dbece1d6