### PR TITLE
Fix mana highlight text rendering order

### DIFF
--- a/Assets/Scripts/ManaColorUtility.cs
+++ b/Assets/Scripts/ManaColorUtility.cs
@@ -47,6 +47,6 @@ public static class ManaColorUtility
             textColorHex = luminance < 0.5f ? "#FFFFFF" : "#000000";
         }
 
-        return $"<mark={markHex}><color={textColorHex}>{amount}</color></mark>";
+        return $"<color={textColorHex}><mark={markHex}>{amount}</mark></color>";
     }
 }


### PR DESCRIPTION
## Summary
- ensure mana cost highlights keep their numeric value visible by reordering TMP tags in `FormatColoredManaNumber`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e6c394cc832e993ace1caa3268b8