### PR TITLE
Display mana costs with colored text

### DIFF
--- a/Assets/Scripts/ManaColorUtility.cs
+++ b/Assets/Scripts/ManaColorUtility.cs
@@ -38,15 +38,7 @@ public static class ManaColorUtility
     {
         string normalized = NormalizeColor(colorName);
         string hex = GetHexCode(normalized);
-        string markHex = hex.Length == 7 ? hex + "FF" : hex;
 
-        string textColorHex = "#000000";
-        if (ColorUtility.TryParseHtmlString(hex, out Color color))
-        {
-            float luminance = 0.2126f * color.r + 0.7152f * color.g + 0.0722f * color.b;
-            textColorHex = luminance < 0.5f ? "#FFFFFF" : "#000000";
-        }
-
-        return $"<color={textColorHex}><mark={markHex}>{amount}</mark></color>";
+        return $"<color={hex}>{amount}</color>";
     }
 }


### PR DESCRIPTION
## Summary
- update mana number formatting to render colored text without background marks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e81e61a4832eaa1339d862828d68