### PR TITLE
Fix undefined `ai` references in deck builder methods

### DIFF
--- a/Assets/Scripts/DeckDatabase.cs
+++ b/Assets/Scripts/DeckDatabase.cs
@@ -336,7 +336,7 @@ public static class DeckDatabase
             ai.StartingPermanents.Add(CardFactory.Create("Wall of Wood"));
         }
 
-    public static void BuildSoldiersAndGloryDeck(Player player)
+    public static void BuildSoldiersAndGloryDeck(Player ai)
     {
         ai.Deck.Clear();
         AddCards(ai, "Plains", 20);
@@ -357,7 +357,7 @@ public static class DeckDatabase
         AddCards(ai, "Holy Strength", 1);
     }
 
-    public static void BuildGreenMachineDeck(Player player)
+    public static void BuildGreenMachineDeck(Player ai)
     {
         ai.Deck.Clear();
         AddCards(ai, "Forest", 22);
@@ -377,7 +377,7 @@ public static class DeckDatabase
         AddCards(ai, "Might of Oaks", 1);
     }
 
-    public static void BuildRedBlackAggroDeck(Player player)
+    public static void BuildRedBlackAggroDeck(Player ai)
     {
         ai.Deck.Clear();
         AddCards(ai, "Swamp", 13);


### PR DESCRIPTION
### Motivation
- Resolve a compile-time `CS0103` caused by method parameters named `player` while method bodies referenced `ai`.

### Description
- Renamed the parameters from `Player player` to `Player ai` for `BuildSoldiersAndGloryDeck`, `BuildGreenMachineDeck`, and `BuildRedBlackAggroDeck` in `Assets/Scripts/DeckDatabase.cs` so the existing `ai` references are in scope.

### Testing
- Ran a targeted source check with `rg -n "Build(SoldiersAndGlory|GreenMachine|RedBlackAggro)Deck|ai\.Deck\.Clear\(\)" Assets/Scripts/DeckDatabase.cs` and confirmed updated signatures and `ai.Deck.Clear()` usage; the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db610da7ac832e99dc22066c8f8495)